### PR TITLE
Use existing pip if pip doesn't reinstall

### DIFF
--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -79,7 +79,11 @@ virtualenv --python=${PYTHON_EXEC_PATH} \
 get_pip /opt/ansible-runtime/bin/python
 
 # The vars used to prepare the Ansible runtime venv
-PIP_COMMAND="/opt/ansible-runtime/bin/pip"
+if [ -f "/opt/ansible-runtime/bin/pip" ]; then
+  PIP_COMMAND="/opt/ansible-runtime/bin/pip"
+else
+  PIP_COMMAND="$(which pip)"
+fi
 PIP_OPTS+=" --constraint global-requirement-pins.txt"
 
 # Install ansible and the other required packages


### PR DESCRIPTION
When the existing pip version matches the version of pip we're trying to
install it won't re-install it. We should just use this pip instead of
forcing the pip in /opt/ansible-runtime.