### PR TITLE
Move to use single repository for ceph-ansible

### DIFF
--- a/ansible-role-requirements-xenial.yml
+++ b/ansible-role-requirements-xenial.yml
@@ -1,25 +1,8 @@
-- name: ceph.ceph-rgw
+- name: ceph-ansible
+  src: https://github.com/ceph/ceph-ansible
   scm: git
-  src: https://github.com/ceph/ansible-ceph-rgw
   version: v2.2.11
-- name: ceph.ceph-common
-  scm: git
-  src: https://github.com/ceph/ansible-ceph-common
-  version: v2.2.11
-- name: ceph.ceph-mon
-  scm: git
-  src: https://github.com/ceph/ansible-ceph-mon
-  version: v2.2.11
-- name: ceph.ceph-osd
-  scm: git
-  src: https://github.com/ceph/ansible-ceph-osd
-  version: v2.2.11
-# Dependency for ceph roles
-- name: ceph.ceph-docker-common
-  src: https://github.com/ceph/ansible-ceph-docker-common
-  scm: git
-  version: master
 - name: ../plugins
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
   scm: git
-  version: master
+  version: stable/pike

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,3 +13,4 @@ filter_plugins     = /etc/ansible/plugins/filter
 test_plugins       = /etc/ansible/plugins/test
 terminal_plugins   = /etc/ansible/plugins/terminal
 strategy_plugins   = /etc/ansible/plugins/strategy
+roles_path         = /etc/ansible/roles:/etc/ansible/roles/ceph-ansible/roles/

--- a/playbooks/deploy-ceph.yml
+++ b/playbooks/deploy-ceph.yml
@@ -37,7 +37,7 @@
   gather_facts: false
   become: True
   roles:
-  - ceph.ceph-mon
+  - ceph-mon
   vars_files:
     - ../tests/test-vars.yml
 
@@ -45,7 +45,7 @@
   gather_facts: false
   become: True
   roles:
-  - ceph.ceph-osd
+  - ceph-osd
   vars_files:
     - ../tests/test-vars.yml
 
@@ -53,6 +53,6 @@
   gather_facts: false
   become: True
   roles:
-  - ceph.ceph-rgw
+  - ceph-rgw
   vars_files:
     - ../tests/test-vars.yml


### PR DESCRIPTION
Instead of cloning all the individual roles we should clone only the
overarching ceph-ansible repository and adjust our ansible.cfg to
include the roles inside ceph-ansible.

Additionally, pin the plugins repository to stable/pike to reduce the
impact of changes upstream.