### PR TITLE
Set default journal size to 20GB

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -7,6 +7,12 @@ ceph_origin: 'upstream' # or 'distro' or 'local'
 ceph_stable: true # use ceph stable branch
 ceph_stable_release: jewel
 
+# Journal size should be 2 * (expected throughput * filestore max sync interval)
+# Our expected max throughput on non-SSD drives is about 140MB/s
+# filestore max sync interval default is 5. So 14GB should be the journal size
+# Let's round that up to 20GB as a lazy/safe option
+osd_journal_size: 20480
+
 radosgw_civetweb_num_threads: 1024
 ceph_conf_overrides:
    global:

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -66,6 +66,8 @@ pip_install_repo_priorities: []
 openstack_host_repo_priorities: []
 
 ## Testing specific Ceph vars
+# We don't have enough space in an AIO to run 20GB journal devices
+osd_journal_size: 2048
 monitor_interface: eth1
 public_network: 10.1.1.0/24
 cluster_network: 10.2.1.0/24


### PR DESCRIPTION
The journal size should be 2 * expected throughput * filestore max sync
interval. Our expected throughput on our best non-SSD drives is 140MB/s.
filestore max interval has a default of 5. That would mean a journal
size of 14GB. Let's round that up to 20GB as a lazy and safe estimate,
for a start point for journal devices.