### PR TITLE
Remove vars_files from deploy-ceph.yml

### DIFF
--- a/playbooks/deploy-ceph.yml
+++ b/playbooks/deploy-ceph.yml
@@ -30,29 +30,21 @@
     - name: install required packages for Fedora > 23
       raw: sudo dnf -y install python2-dnf libselinux-python ntp
       when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 23
-  vars_files:
-    - ../tests/test-vars.yml
 
 - hosts: mons
   gather_facts: false
   become: True
   roles:
   - ceph-mon
-  vars_files:
-    - ../tests/test-vars.yml
 
 - hosts: osds
   gather_facts: false
   become: True
   roles:
   - ceph-osd
-  vars_files:
-    - ../tests/test-vars.yml
 
 - hosts: rgws
   gather_facts: false
   become: True
   roles:
   - ceph-rgw
-  vars_files:
-    - ../tests/test-vars.yml


### PR DESCRIPTION
We shouldn't reference a test vars file in a playbook we plan to use in
produciton. The test-vars.yml file is already included via -e @ inside
the run_tests.sh - which is not designed to be run against production,
and is only designed to run an AIO for testing.