### PR TITLE
[CEPHSTORA-18] Add FIO benchmark playbook

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,12 @@
+[global]
+randrepeat=0
+runtime=180
+
+[fio_direct_read_test]
+filename={{ bench_direct_device_name }}
+direct=1
+rw=read
+ioengine=libaio
+bs=1024k
+iodepth=8
+time_based=1

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,53 @@
+## rpc-ceph FIO benchmarking
+
+A set of playbooks to setup and configure an rbd device for
+benchmarking, based on the Amazon EBS Benchmark Procedures:
+http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/benchmark_procedures.html
+
+Run the fio_benchmark.yml to setup, run and cleanup the benchmark pool,
+ceph user, and mount point. Add the "benchmark_hosts" inventory group to specify
+the host on which to run the benchmarks.
+
+### Specifying a pool
+If you would like to use an existing Ceph pool specify this using the
+"fiobench_pool_name" variable. If you specify this the scripts will not create
+or cleanup pools and will just use that pool to create an image. Otherwise
+the scripts will create a pool name "fiobench". You can specify the pgnum and
+pgpnum for this pool by specifying the fiobench_pgnum and fiobench_pgpnum
+variables, which default to 100.
+
+### Specifying image size
+You can specify the size of the image using "fiobench_size" variable which
+defaults to 2G. This will be created in the specified pool, or the default
+"fiobench" pool.
+
+### Test options
+FIO options can be set using config_template overrides for each test.
+The 5 test scenarios and their corresponding overrides vars are:
+fio_direct_read_test - fio_direct_read_test_overrides
+fio_direct_write_test - fio_direct_write_test_overrides
+fio_rw_mix - fio_rw_mix_overrides
+fio_test_file_read - fio_test_file_read_overrides
+fio_test_file_write - fio_test_file_write_overrides
+
+### Running tests
+There are 5 test scenarios based on the document linked above. These are
+meant to represent tests for SSDs and SATA devices. By default all 5 tests will
+run in serial, and output logs to /opt/ceph_fiobench/<test>.<timestamp>.log.
+This means multiple test runs will generate multiple logs. Additionally, the log
+will store an output of "fio --version" as well as the config used in the test.
+If you would like to run only the sata tests set "ssd_bench=False", or for only
+ssd tests set "sata_bench=False".
+
+SATA tests:
+fio_rw_mix
+fio_direct_read_test
+fio_direct_write_test
+
+SSD Tests:
+fio_test_file_read
+fio_test_file_write
+
+### Cleaning up a deploy
+The cleanup script will unmount, unmap and remove the rbd image, as well as
+delete the fiobench pool if "fiobench_pool_name" is not specified.

--- a/benchmark/fio_benchmark.yml
+++ b/benchmark/fio_benchmark.yml
@@ -1,0 +1,4 @@
+---
+- include: fio_benchmark_setup.yml
+- include: fio_benchmark_run.yml
+- include: fio_benchmark_cleanup.yml

--- a/benchmark/fio_benchmark_cleanup.yml
+++ b/benchmark/fio_benchmark_cleanup.yml
@@ -1,0 +1,66 @@
+---
+- hosts: benchmark_hosts
+  become: True
+  tasks:
+    - name: Get bench_direct_device_name
+      shell: "rbd-nbd list-mapped | grep ' {{ fiobench_pool_name | default('fiobench') }} ' | grep ' bench_direct ' | awk '{ print $5 }'"
+      register: _find_bench_direct_device_name
+      when: bench_direct_device_name is not defined
+    - name: Get bench_file_device_name
+      shell: "rbd-nbd list-mapped | grep ' {{ fiobench_pool_name | default('fiobench') }} ' | grep ' bench_file ' | awk '{ print $5 }'"
+      register: _find_bench_file_device_name
+      when: bench_file_device_name is not defined
+    - name: Set bench_device_name vars
+      set_fact:
+        _bench_direct_device_name: "{{ bench_direct_device_name | default(_find_bench_direct_device_name.stdout) }}"
+        _bench_file_device_name: "{{ bench_file_device_name | default(_find_bench_file_device_name.stdout) }}"
+    - name: Unmount device
+      mount:
+        src: "{{ _bench_file_device_name }}"
+        fstype: xfs
+        state: unmounted
+        path: "/mnt/fio_bench"
+    - name: Ensure mount is removed from fstab
+      mount:
+        src: "{{ _bench_file_device_name }}"
+        fstype: xfs
+        state: absent
+        path: "/mnt/fio_bench"
+    - name: Remove /mnt/fio_bench directory
+      file:
+        state: absent
+        path: "/mnt/fio_bench"
+    - name: Unmap rbd-nbd device
+      command: "rbd-nbd unmap {{ item }}"
+      with_items:
+        - "{{ _bench_direct_device_name }}"
+        - "{{ _bench_file_device_name }}"
+    - name: Delete image
+      command: "rbd remove {{ fiobench_pool_name | default('fiobench') }}/{{ item }} -k /etc/ceph/ceph.client.fiobench.keyring -n client.fiobench"
+      with_items:
+        - "bench_file"
+        - "bench_direct"
+
+# Cleanup the benchmark pool if we created it
+- hosts: mons[0]
+  become: True
+  tasks:
+    - name: Check the value of mon_allow_pool_delete
+      shell: "ceph daemon mon.{{ ansible_hostname }} config get mon_allow_pool_delete | grep -q false"
+      register: allow_pool_delete
+      when: fiobench_pool_name is not defined
+    - name: Set to mon_allow_pool_delete if it isn't already
+      command: "ceph daemon mon.{{ ansible_hostname }} config set mon_allow_pool_delete true"
+      when:
+        - fiobench_pool_name is not defined
+        - allow_pool_delete.rc == 0
+    - name: Delete fiobench pool
+      command: "ceph osd pool delete fiobench fiobench --yes-i-really-really-mean-it"
+      when: fiobench_pool_name is not defined
+    - name: Set the mon_allow_pool_delete to false if it was before
+      command: "ceph daemon mon.{{ ansible_hostname }} config set mon_allow_pool_delete false"
+      when:
+        - fiobench_pool_name is not defined
+        - allow_pool_delete.rc == 0
+    - name: Remove client.fiobench user
+      command: "ceph auth del client.fiobench"

--- a/benchmark/fio_benchmark_run.yml
+++ b/benchmark/fio_benchmark_run.yml
@@ -1,0 +1,24 @@
+---
+- hosts: benchmark_hosts
+  become: True
+  gather_facts: True
+  tasks:
+    - name: Run fio jobs and record version/config info
+      shell: 'echo -e "FIO Version: `fio --version`\nFIO Config Used:\n`cat /opt/ceph_bench/{{ item.name }}`\n\nFIO Test Output:\n`fio /opt/ceph_bench/{{ item.name }}`" | tee /opt/ceph_bench/logs/{{ item.name }}.{{ ansible_date_time.iso8601_basic_short }}.log'
+      register: fio_output
+      with_items:
+        - name: "fio_direct_read_test.cfg"
+          run_type: (sata_bench | default(True))
+        - name: "fio_direct_write_test.cfg"
+          run_type: (sata_bench | default(True))
+        - name: "fio_rw_mix.cfg"
+          run_type: (sata_bench | default(True))
+        - name: "fio_test_file_write.cfg"
+          run_type: (ssd_bench | default(True))
+        - name: "fio_test_file_read.cfg"
+          run_type: (ssd_bench | default(True))
+      when: item.run_type
+    - name: Debug fio outputs
+      debug:
+        var: item.stdout_lines
+      with_items: "{{ fio_output.results }}"

--- a/benchmark/fio_benchmark_setup.yml
+++ b/benchmark/fio_benchmark_setup.yml
@@ -1,0 +1,95 @@
+---
+- hosts:
+    - mons
+  gather_facts: True
+  become: True
+  tasks:
+    - name: Create fiobench pool
+      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(100) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(100)) }}"
+      run_once: True
+      when: fiobench_pool_name is not defined
+    - name: Create benchmark ceph client
+      command: "ceph auth get-or-create client.fiobench mon 'allow r' osd 'allow * pool={{ fiobench_pool_name | default('fiobench') }}'"
+      when: inventory_hostname == groups['mons'][0]
+      register: _ceph_benchmark_client
+    - name: Set benchmark_client fact
+      set_fact:
+        ceph_benchmark_client: "{{ _ceph_benchmark_client }}"
+
+- hosts: benchmark_hosts
+  gather_facts: True
+  become: True
+  post_tasks:
+    - name: Install benchmark package
+      package:
+        name: "{{ item }}"
+        state: present
+        use: "{{ ansible_pkg_mgr }}"
+      with_items:
+        - fio
+        - rbd-nbd
+        - xfsprogs
+    - name: Write ceph benchmark client key to file
+      copy:
+        content: "{{ [hostvars[groups['mons'][0]]['ceph_benchmark_client']['stdout'], '\n'] | join('') }}"
+        dest: "/etc/ceph/ceph.client.fiobench.keyring"
+    - name: Create a ceph device for benchmarking
+      command: "rbd create {{ fiobench_pool_name | default('fiobench') }}/{{ item }} -s {{ fiobench_size | default(2048) }} -n client.fiobench -k /etc/ceph/ceph.client.fiobench.keyring"
+      with_items:
+        - bench_direct
+        - bench_file
+    - name: Map nbd direct device
+      command: "rbd-nbd map {{ fiobench_pool_name | default('fiobench') }}/bench_direct -k /etc/ceph/ceph.client.fiobench.keyring -n client.fiobench"
+      register: _nbd_direct_device
+    - name: Map nbd file device
+      command: "rbd-nbd map {{ fiobench_pool_name | default('fiobench') }}/bench_file -k /etc/ceph/ceph.client.fiobench.keyring -n client.fiobench"
+      register: _nbd_file_device
+    - name: Set bench_device_name facts
+      set_fact:
+        bench_direct_device_name: "{{ _nbd_direct_device.stdout }}"
+        bench_file_device_name: "{{ _nbd_file_device.stdout}}"
+    - name: Create xfs file system on device
+      filesystem:
+        fstype: xfs
+        device: "{{ item }}"
+      with_items:
+        - "{{ bench_direct_device_name }}"
+        - "{{ bench_file_device_name }}"
+    - name: Create benchmark directories
+      file:
+        state: directory
+        path: "{{ item }}"
+      with_items:
+        - /opt/ceph_bench/logs
+        - /mnt/fio_bench
+    - name: Template out fio_bench files
+      config_template:
+        src: "templates/{{ item.name }}.j2"
+        dest: "/opt/ceph_bench/{{ item.name }}"
+        config_overrides: "{{ item.override }}"
+        config_type: "ini"
+      with_items:
+        - name: "fio_direct_read_test.cfg"
+          override: "{{ fio_direct_read_test_overrides | default({}) }}"
+        - name: "fio_direct_write_test.cfg"
+          override: "{{ fio_direct_write_test_overrides | default({}) }}"
+        - name: "fio_rw_mix.cfg"
+          override: "{{ fio_rw_mix_overrides | default({}) }}"
+        - name: "fio_test_file_read.cfg"
+          override: "{{ fio_test_file_read_overrides | default({}) }}"
+        - name: "fio_test_file_write.cfg"
+          override: "{{ fio_test_file_write_overrides | default({}) }}"
+    # In py2 ConfigParser cant strip spaces around delimiters FIO needs that.
+    - name: Manually strip spaces around delimiters
+      shell: "sed -i 's/ = /=/g' /opt/ceph_bench/*.cfg"
+    - name: Mount image
+      mount:
+        src: "{{ bench_file_device_name }}"
+        fstype: "xfs"
+        name: "/mnt/fio_bench"
+        state: mounted
+  roles:
+    - ceph-defaults
+    - ceph-common
+    - ceph-config
+    - ceph-client

--- a/benchmark/templates/fio_direct_read_test.cfg.j2
+++ b/benchmark/templates/fio_direct_read_test.cfg.j2
@@ -1,0 +1,12 @@
+[global]
+randrepeat=0
+runtime=180
+
+[fio_direct_read_test]
+filename={{ bench_direct_device_name }}
+direct=1
+rw=read
+ioengine=libaio
+bs=1024k
+iodepth=8
+time_based=1

--- a/benchmark/templates/fio_direct_write_test.cfg.j2
+++ b/benchmark/templates/fio_direct_write_test.cfg.j2
@@ -1,0 +1,12 @@
+[global]
+randrepeat=0
+runtime=180
+
+[fio_direct_write_test]
+filename={{ bench_direct_device_name }}
+direct=1
+rw=write
+ioengine=libaio
+bs=1024k
+iodepth=8
+time_based=1

--- a/benchmark/templates/fio_rw_mix.cfg.j2
+++ b/benchmark/templates/fio_rw_mix.cfg.j2
@@ -1,0 +1,27 @@
+[global]
+clocksource=clock_gettime
+randrepeat=0
+runtime=180
+offset_increment=100g
+
+[sequential-write]
+bs=1M
+ioengine=libaio
+direct=1
+iodepth=8
+filename={{ bench_direct_device_name }}
+do_verify=0
+rw=write
+rwmixread=0
+rwmixwrite=100
+
+[sequential-read]
+bs=1M
+ioengine=libaio
+direct=1
+iodepth=8
+filename={{ bench_direct_device_name }}
+do_verify=0
+rw=read
+rwmixread=100
+rwmixwrite=0

--- a/benchmark/templates/fio_test_file_read.cfg.j2
+++ b/benchmark/templates/fio_test_file_read.cfg.j2
@@ -1,0 +1,13 @@
+[global]
+runtime=180
+group_reporting=1
+norandommap=1
+
+[fio_test_file]
+directory=/mnt/fio_bench
+bs=16k
+rw=randread
+direct=1
+size=1G
+numjobs=16
+time_based=1

--- a/benchmark/templates/fio_test_file_write.cfg.j2
+++ b/benchmark/templates/fio_test_file_write.cfg.j2
@@ -1,0 +1,13 @@
+[global]
+runtime=180
+group_reporting=1
+norandommap=1
+
+[fio_test_file]
+directory=/mnt/fio_bench
+bs=16k
+rw=randwrite
+direct=1
+size=1G
+numjobs=16
+time_based=1

--- a/tests/inventory
+++ b/tests/inventory
@@ -46,3 +46,6 @@ allsvc
 
 [rsyslog_all]
 localhost
+
+[benchmark_hosts]
+localhost

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -10,3 +10,4 @@
 
 - include: test-rgw.yml
 - include: test-logging.yml
+- include: ../benchmark/fio_benchmark.yml

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -79,6 +79,27 @@ ceph_mgr_systemd_overrides:
   Service:
     PrivateDevices: False
 
+## Testing specific fio_bench vars
+fio_direct_read_test_overrides:
+  global:
+    runtime: 10
+fio_direct_write_test_overrides:
+  global:
+    runtime: 10
+fio_rw_mix_overrides:
+  global:
+    runtime: 10
+fio_test_file_read_overrides:
+  global:
+    runtime: 10
+  fio_test_file:
+    size: 10M
+fio_test_file_write_overrides:
+  global:
+    runtime: 10
+  fio_test_file:
+    size: 10M
+
 ## Testing specific Ceph vars
 # We don't have enough space in an AIO to run 20GB journal devices
 osd_journal_size: 2048


### PR DESCRIPTION
Adds fio tests based on EBS benchmark procedures:
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/benchmark_procedures.html

Adds a run of the ebs_benchmark to testing.