### PR TITLE
Minimal fix for roles var

### DIFF
--- a/playbooks/git-clone-repos.yml
+++ b/playbooks/git-clone-repos.yml
@@ -15,11 +15,11 @@
       force: true
     when:
       - item.scm == "git" or item.scm is undefined
-    with_items: "{{ roles }}"
+    with_items: "{{ clone_roles }}"
     register: _git_clone
     until: _git_clone | success
     retries: 2
     delay: 5
 
   vars:
-    roles: "{{ lookup('file', role_file)  | from_yaml }}"
+    clone_roles: "{{ lookup('file', role_file)  | from_yaml }}"


### PR DESCRIPTION
Avoid deprecation warning by moving from using a reserved var name
"roles" and instead use "clone_roles".