### PR TITLE
Allow the size of the osd/journal devices to be set

### DIFF
--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -25,7 +25,7 @@
       name: xfsprogs
       state: present
   - name: Create Ceph files
-    shell: "fallocate -l 10G /opt/{{ container_name }}_{{ item }}.img"
+    shell: "fallocate -l {{ rpc_ceph_test_osd_size }} /opt/{{ container_name }}_{{ item }}.img"
     args:
       creates: "/opt/{{ container_name }}_{{ item }}.img"
     with_items:

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -101,6 +101,10 @@ fio_test_file_write_overrides:
     size: 10M
 
 ## Testing specific Ceph vars
+# Set the size of the OSD and journal devices
+# NB if you change the size you will need to change the osd_journal_size
+# We setup 3 osds + 1 journal per host, there are 3 hosts.
+rpc_ceph_test_osd_size: 10G
 # We don't have enough space in an AIO to run 20GB journal devices
 osd_journal_size: 2048
 monitor_interface: eth1


### PR DESCRIPTION
Using the rpc_ceph_test_osd_size var we can now set the size of the osd
and journal devices.
We setup 4 per host, and there are 3 OSD hosts, so that will mean we
need 12x rpc_ceph_test_osd_size spare on the AIO localhost.

In order to use this we will need to ensure the osd_journal_size is
rpc_ceph_test_osd_size/3 otherwise the journals will be too big for the
journal partition.