### PR TITLE
Reduce size of AIO build

### DIFF
--- a/tests/cleanup-ceph-storage.yml
+++ b/tests/cleanup-ceph-storage.yml
@@ -6,7 +6,6 @@
   with_items:
     - drive1
     - drive2
-    - drive3
     - journ1
   delegate_to: "{{ physical_host }}"
 - name: Clean up losetup devices

--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -31,7 +31,6 @@
     with_items:
       - drive1
       - drive2
-      - drive3
       - journ1
     register: ceph_create
     delegate_to: "{{ physical_host }}"
@@ -40,7 +39,6 @@
     with_items:
       - drive1
       - drive2
-      - drive3
       - journ1
     register: ceph_losetup
     delegate_to: "{{ physical_host }}"
@@ -61,7 +59,6 @@
         - "lxc.cgroup.devices.allow = b {{ block_devs.results[0].stdout }} rwm"
         - "lxc.cgroup.devices.allow = b {{ block_devs.results[1].stdout }} rwm"
         - "lxc.cgroup.devices.allow = b {{ block_devs.results[2].stdout }} rwm"
-        - "lxc.cgroup.devices.allow = b {{ block_devs.results[3].stdout }} rwm"
     delegate_to: "{{ physical_host }}"
   - name: Wait for container connectivity
     wait_for_connection:

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -104,9 +104,9 @@ fio_test_file_write_overrides:
 # Set the size of the OSD and journal devices
 # NB if you change the size you will need to change the osd_journal_size
 # We setup 3 osds + 1 journal per host, there are 3 hosts.
-rpc_ceph_test_osd_size: 10G
+rpc_ceph_test_osd_size: 3G
 # We don't have enough space in an AIO to run 20GB journal devices
-osd_journal_size: 2048
+osd_journal_size: 1024
 monitor_interface: eth1
 public_network: 10.1.1.0/24
 cluster_network: 10.2.1.0/24
@@ -114,9 +114,7 @@ osd_scenario: non-collocated
 devices:
   - /dev/sda1
   - /dev/sdb1
-  - /dev/sdc1
 
 dedicated_devices:
-  - /dev/sdd1
-  - /dev/sdd1
-  - /dev/sdd1
+  - /dev/sdc1
+  - /dev/sdc1


### PR DESCRIPTION
We were building 3 OSDs per OSD host at 10GB each + a journal, this
equated to 120GB (40/host), which is quite a storage footprint for an
AIO.

We don't need to build that many OSDs, and we can also reduce the size
of each disk used, as well as the journal. By dropping to 2 drives per
host + journal, and setting the size to 3GB each, we can reduce this to
27GB instead of 120.

If we need further space we could consider removing one of the OSD
hosts.