### PR TITLE
Unblock failing gate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,15 @@
 # process, which may cause wedges in the gate later.
 pyasn1!=0.2.3 # BSD
 pyOpenSSL>=0.14 # Apache-2.0
-requests>=2.14.2 # Apache-2.0
+# NOTE(mattt): This pulls in urllib3, so we disable to avoid the issue
+#              mentioned below
+#requests>=2.14.2 # Apache-2.0
 ndg-httpsclient>=0.4.2;python_version<'3.0' # BSD
 netaddr!=0.7.16,>=0.7.13 # BSD
 PrettyTable<0.8,>=0.7.1 # BSD
 pycrypto>=2.6 # Public Domain
 python-memcached>=1.56 # PSF
 PyYAML>=3.10.0 # MIT
-urllib3>=1.21.1 # MIT
+# NOTE(mattt): This causes issues w/ ansible's apt_key module and SNI
+#urllib3>=1.21.1 # MIT
 virtualenv>=13.1.0 # MIT

--- a/tests/host_vars/osd2.yml
+++ b/tests/host_vars/osd2.yml
@@ -1,0 +1,16 @@
+---
+ansible_host: "{{ ansible_addr_prefix }}.105"
+ceph_storage_address: "{{ storage_addr_prefix }}.105"
+container_networks:
+  management_address:
+    address: "{{ ansible_host }}"
+    bridge: "br-mgmt"
+    interface: "eth1"
+    netmask: "255.255.255.0"
+    type: "veth"
+  storage_address:
+    address: "{{ ceph_storage_address }}"
+    bridge: "br-storage"
+    interface: "eth2"
+    netmask: "255.255.255.0"
+    type: "veth"

--- a/tests/inventory
+++ b/tests/inventory
@@ -3,6 +3,7 @@ localhost
 mon1
 mon2
 osd1
+osd2
 allsvc
 rgw1
 mgr1
@@ -15,6 +16,7 @@ localhost
 mon1
 mon2
 osd1
+osd2
 rgw1
 mgr1
 mgr2
@@ -31,6 +33,7 @@ allsvc
 
 [osds]
 osd1
+osd2
 allsvc
 
 [mgrs]

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -63,6 +63,7 @@ device_mapping:
 openstack_host_rdo_repos: []
 pip_install_rdo_repos: []
 pip_install_repo_priorities: []
+uca_enable: False
 openstack_host_repo_priorities: []
 
 ## Container specific Ceph vars for running services in containers


### PR DESCRIPTION
We're currently hitting a number of issues gating rpc-ceph at the
moment.

1. Because OSDs were recently reduced from 3 to 2, the ceph cluster is
   now always in a non-healthy state.  Additionally, we're seeing the
   `Create fiobench pool` task fail because "pg_num 100 size 3 would
   mean 984 total pgs, which exceeds max 800 (mon_max_pg_per_osd 200 *
   num_in_osds 4)".
2. pip_install is dropping the UCA repo, resulting in the ceph packages
   installed on localhost (for fiobench testing) are different than
   those installed throughout the rest of the cluster.
3. When we deploy rpc-maas, localhost fails to add the apt_key for
   https://repos.influxdata.com/.  This key gets installed fine inside
   all containers and while I'm unsure of the specifics it appears that
   this is due to urllib3 being installed on localhost.

To address, we:

1. Re-add the 3rd OSD container back in (a future solution would be to
   set the osd default pool size to 2, if 2 OSD containers is preferred).
2. Override `uca_enable` so this repo is not dropped on localhost.
3. Remove urllib3 and requests from requirements.txt.

Regarding #3, we seem to install a # of packages via apt, then via pip
to the system python install, as well as to the ansible runtime venv.
It's unclear what needs to be installed where but this commit is simply
to unblock the gate, so this can be reverted/reworked at a later time.

Co-Authored-By: Jay Payne <letterj@gmail.com>