### PR TITLE
Remove uca_enable: False

### DIFF
--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -62,7 +62,6 @@ device_mapping:
 openstack_host_rdo_repos: []
 pip_install_rdo_repos: []
 pip_install_repo_priorities: []
-uca_enable: False
 openstack_host_repo_priorities: []
 
 ## Container specific Ceph vars for running services in containers


### PR DESCRIPTION
We should use UCA, it'll provide newer packages, and we shouldn't test
against packages we wouldn't deploy in prod. Since the change only
applied to gating it would mean we are testing against packages we don't
use in prod.