### PR TITLE
[CEPHSTORA-51] Use maas_use_api for Ceph tests

### DIFF
--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -3,7 +3,6 @@ force_containers_destroy: True
 force_containers_data_destroy: False
 ansible_addr_prefix: "10.1.1"
 storage_addr_prefix: "10.2.1"
-maas_rpc_legacy_ceph: True
 container_name: "{{ inventory_hostname }}"
 physical_host: localhost
 properties:
@@ -117,3 +116,15 @@ devices:
 dedicated_devices:
   - /dev/sdc
   - /dev/sdc
+
+### MaaS settings
+# Enable the API usage
+maas_use_api: true
+# Will restart the agent service ONLY once at the end of a site.yml run
+maas_restart_independent: false
+# Set the default notification plan, in the gate this is set here
+maas_notification_plan: npTechnicalContactsEmail
+# Set the MaaS entity to be ansible_hostname instead of inventory_hostname
+maas_entity_name: "{{ ansible_hostname }}{{ maas_fqdn_extension }}"
+# Allow ceph services to be inside containers.
+maas_rpc_legacy_ceph: True


### PR DESCRIPTION
We don't use the MaaS api which is giving us some fake results when
monitoring would fail, but is showing up as passing still.

We can fix this by enabling it and specifying the maas_entity_name to be
the ansible_hostname rather than the inventory_hostname for tests since
localhost will not show up as an entity.

These settings are all setup in /etc/openstack_deploy/user_*_vars.yml
for the OpenStack installs, but are not configured for MaaS at all.