### PR TITLE
RO-3487 Don't use the same ansible venv as OSA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ The inventory should consist of the following:
    * ``cluster_network``
    * ``osd_scenario``
    * Any other ``ceph-ansible`` settings you want to configure.
-  
+
 3. Run the ``bootstrap-ansible.sh`` inside the scripts directory:
 
-   ```
-   # ./scripts/bootstrap-ansible.sh
+   ```bash
+   ./scripts/bootstrap-ansible.sh
    ```
 
 4. This configures ansible at a pre-tested version and clones the required role repositories:
@@ -75,8 +75,8 @@ The inventory should consist of the following:
 
 5. Run the ``ceph-ansible`` playbook from the playbooks directory:
 
-   ```
-   # ansible-playbook -i <link to your inventory file> playbooks/deploy-ceph.yml -e @<link to your vars file>
+   ```bash
+   /opt/rpc-ceph_ansible-runtime/bin/ansible-playbook -i <link to your inventory file> playbooks/deploy-ceph.yml -e @<link to your vars file>
    ```
 
 Your deployment should be successful.
@@ -96,7 +96,7 @@ Your deployment should be successful.
 For MaaS integration, perform the following export commands.
 Otherwise just use ``./run_tests.sh`` to build the AIO.
 
-```
+```bash
 export PUBCLOUD_USERNAME=<username>
 export PUBCLOUD_API_KEY=<api_key>
 export IRR_CONTEXT=master

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -53,15 +53,16 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   export CLONE_DIR="$(pwd)"
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
   export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
-  export ANSIBLE_BINARY="ansible-playbook"
+  export ANSIBLE_BINARY="/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook"
   bash scripts/bootstrap-ansible.sh
   # Clone the test repos
   pushd playbooks
-    ansible-playbook git-clone-repos.yml \
-                     -i ${CLONE_DIR}/tests/inventory \
-                     -e role_file=../ansible-role-test-requirements.yml
+    "${ANSIBLE_BINARY}" git-clone-repos.yml \
+         -i ${CLONE_DIR}/tests/inventory \
+         -e role_file=../ansible-role-test-requirements.yml
   popd
-  ansible-playbook -i tests/inventory tests/setup-ceph-aio.yml -e @tests/test-vars.yml
+  "${ANSIBLE_BINARY}" -i tests/inventory tests/setup-ceph-aio.yml \
+      -e @tests/test-vars.yml
   # Use the rpc-maas deploy to test MaaS
   if [ "${IRR_CONTEXT}" != "ceph" ]; then
     pushd ${RPC_MAAS_DIR}

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -74,23 +74,23 @@ fi
 pip install --requirement requirements.txt
 
 # Create a Virtualenv for the Ansible runtime
-if [ -f "/opt/ansible-runtime/bin/python" ]; then
-  VENV_PYTHON_VERSION="$(/opt/ansible-runtime/bin/python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
+if [ -f "/opt/rpc-ceph_ansible-runtime/bin/python" ]; then
+  VENV_PYTHON_VERSION="$(/opt/rpc-ceph_ansible-runtime/bin/python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
   if [ "$PYTHON_VERSION" != "$VENV_PYTHON_VERSION" ]; then
-    rm -rf /opt/ansible-runtime
+    rm -rf /opt/rpc-ceph_ansible-runtime
   fi
 fi
 virtualenv --python=${PYTHON_EXEC_PATH} \
            --clear \
            --no-pip --no-setuptools --no-wheel \
-           /opt/ansible-runtime
+           /opt/rpc-ceph_ansible-runtime
 
 # Install pip, setuptools and wheel into the venv
-get_pip /opt/ansible-runtime/bin/python
+get_pip /opt/rpc-ceph_ansible-runtime/bin/python
 
 # The vars used to prepare the Ansible runtime venv
-if [ -f "/opt/ansible-runtime/bin/pip" ]; then
-  PIP_COMMAND="/opt/ansible-runtime/bin/pip"
+if [ -f "/opt/rpc-ceph_ansible-runtime/bin/pip" ]; then
+  PIP_COMMAND="/opt/rpc-ceph_ansible-runtime/bin/pip"
 else
   PIP_COMMAND="$(which pip)"
 fi
@@ -99,29 +99,16 @@ PIP_OPTS+=" --constraint global-requirement-pins.txt"
 # Install ansible and the other required packages
 ${PIP_COMMAND} install ${PIP_OPTS} -r requirements.txt ${ANSIBLE_PACKAGE}
 
-# Ensure that Ansible binaries run from the venv
-pushd /opt/ansible-runtime/bin
-  for ansible_bin in $(ls -1 ansible*); do
-    if [ "${ansible_bin}" == "ansible" ] || [ "${ansible_bin}" == "ansible-playbook" ]; then
-
-      # For any other commands, we want to link directly to the binary
-      ln -sf /opt/ansible-runtime/bin/${ansible_bin} /usr/local/bin/${ansible_bin}
-
-    fi
-  done
-popd
-
 # Update dependent roles
 if [ -f "${ANSIBLE_ROLE_FILE}" ]; then
   if [[ "${ANSIBLE_ROLE_FETCH_MODE}" == 'galaxy' ]];then
     # Pull all required roles.
-    ansible-galaxy install --role-file="${ANSIBLE_ROLE_FILE}" \
-                           --force
+    /opt/rpc-ceph_ansible-runtime/bin/ansible-galaxy install \
+        --role-file="${ANSIBLE_ROLE_FILE}" --force
   elif [[ "${ANSIBLE_ROLE_FETCH_MODE}" == 'git-clone' ]];then
     pushd playbooks
-      ansible-playbook git-clone-repos.yml \
-                       -i ${CLONE_DIR}/tests/inventory \
-                       -e role_file=${ANSIBLE_ROLE_FILE}
+      /opt/rpc-ceph_ansible-runtime/bin/ansible-playbook git-clone-repos.yml \
+          -i ${CLONE_DIR}/tests/inventory -e role_file=${ANSIBLE_ROLE_FILE}
     popd
   else
     echo "Please set the ANSIBLE_ROLE_FETCH_MODE to either of the following options ['galaxy', 'git-clone']"


### PR DESCRIPTION
If bootstraping OSA and rpc-ceph from the same box they can interfere
with eachother (not install needed deps for instance).  Since all we
need is ansible-playbook just run it from the venv directly.