### PR TITLE
 CEPHSTORA-69 Changes for rpc-maas/tox

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -53,7 +53,6 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   export CLONE_DIR="$(pwd)"
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
   export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
-  export ANSIBLE_BINARY="/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook"
   export ANSIBLE_BINARY="${ANSIBLE_BINARY:-/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook}"
   bash scripts/bootstrap-ansible.sh
   # Clone the test repos

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -54,6 +54,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
   export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
   export ANSIBLE_BINARY="/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook"
+  export ANSIBLE_BINARY="${ANSIBLE_BINARY:-/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook}"
   bash scripts/bootstrap-ansible.sh
   # Clone the test repos
   pushd playbooks


### PR DESCRIPTION

instead of calling rpc-ceph and having ansible installed to /opt/ansible-runtime like it should have, it was using tox's pip in /var/lib/jenkins/workspace/RPC-IRR_rpc-maas-master-xenial-ceph/rcbops/rpc-maas/.tox/functional/bin/pip and installing it to /var/lib/jenkins/workspace/RPC-IRR_rpc-maas-master-xenial-ceph/rcbops/rpc-maas/.tox/functional/lib somewhere
and because we were using export ANSIBLE_BINARY="ansible-playbook", it was finding the ansible-playbook command in  /var/lib/jenkins/workspace/RPC-IRR_rpc-maas-master-xenial-ceph/rcbops/rpc-maas/.tox/functional/bin but now rpc-ceph sets ANSIBLE_BINARY="/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook", it pukes because ansible wasn't installed there


This change will set ANSIBLE_BINARY correctly if it "/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook" is installed or not.