### PR TITLE
[CEPHSTORA-68] Use correct version of Ansible for ceph-ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The inventory should consist of the following:
    ./scripts/bootstrap-ansible.sh
    ```
 
-4. This configures ansible at a pre-tested version and clones the required role repositories:
+4. This configures ansible at a pre-tested version, creates a ``ceph-ansible``
+   binary that points to the appropriate ansible-playbook binary, and clones the
+   required role repositories:
 
    * ``ceph-ansible``
    * ``rsyslog_client``
@@ -76,7 +78,7 @@ The inventory should consist of the following:
 5. Run the ``ceph-ansible`` playbook from the playbooks directory:
 
    ```bash
-   /opt/rpc-ceph_ansible-runtime/bin/ansible-playbook -i <link to your inventory file> playbooks/deploy-ceph.yml -e @<link to your vars file>
+   ceph-ansible -i <link to your inventory file> playbooks/deploy-ceph.yml -e @<link to your vars file>
    ```
 
 Your deployment should be successful.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -39,9 +39,6 @@ if ! which pip; then
     https://bootstrap.pypa.io/get-pip.py | sudo python2.7
 fi
 
-# Install bindep and tox with pip.
-sudo pip install bindep tox
-
 # CentOS 7 requires two additional packages:
 #   redhat-lsb-core - for bindep profile support
 #   epel-release    - required to install python-ndg_httpsclient/python2-pyasn1
@@ -53,14 +50,12 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   export CLONE_DIR="$(pwd)"
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
   export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
-  export ANSIBLE_BINARY="${ANSIBLE_BINARY:-/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook}"
+  export ANSIBLE_BINARY="${ANSIBLE_BINARY:-ceph-ansible}"
   bash scripts/bootstrap-ansible.sh
   # Clone the test repos
-  pushd playbooks
-    "${ANSIBLE_BINARY}" git-clone-repos.yml \
-         -i ${CLONE_DIR}/tests/inventory \
-         -e role_file=../ansible-role-test-requirements.yml
-  popd
+  "${ANSIBLE_BINARY}" playbooks/git-clone-repos.yml \
+       -i ${CLONE_DIR}/tests/inventory \
+       -e role_file=../ansible-role-test-requirements.yml
   "${ANSIBLE_BINARY}" -i tests/inventory tests/setup-ceph-aio.yml \
       -e @tests/test-vars.yml
   # Use the rpc-maas deploy to test MaaS

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -99,6 +99,46 @@ PIP_OPTS+=" --constraint global-requirement-pins.txt"
 # Install ansible and the other required packages
 ${PIP_COMMAND} install ${PIP_OPTS} -r requirements.txt ${ANSIBLE_PACKAGE}
 
+# Create ceph-ansible binary ensuring we use the correct version of ansible
+cat > /usr/local/bin/ceph-ansible <<EOF
+#!/usr/bin/env bash
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper to ensure ceph-ansible is deployed using the Ansible version
+# and dependencies required by ceph-ansible.
+
+function info() {
+    if [ "\${ANSIBLE_NOCOLOR:-0}" -eq "1" ]; then
+      echo -e "\${@}"
+    else
+      echo -e "\e[0;35m\${@}\e[0m"
+    fi
+}
+
+RUN_CMD=\$(basename \${0})
+
+if [ "\${RUN_CMD}" == "ceph-ansible" ] || [ "\${RUN_CMD}" == "ansible-playbook" ]; then
+  /opt/rpc-ceph_ansible-runtime/bin/ansible-playbook "\${@}"
+else
+  \${RUN_CMD} "\${@}"
+fi
+EOF
+
+chmod +x /usr/local/bin/ceph-ansible
+echo "ceph-ansible wrapper created."
+
 # Update dependent roles
 if [ -f "${ANSIBLE_ROLE_FILE}" ]; then
   if [[ "${ANSIBLE_ROLE_FETCH_MODE}" == 'galaxy' ]];then
@@ -106,10 +146,8 @@ if [ -f "${ANSIBLE_ROLE_FILE}" ]; then
     /opt/rpc-ceph_ansible-runtime/bin/ansible-galaxy install \
         --role-file="${ANSIBLE_ROLE_FILE}" --force
   elif [[ "${ANSIBLE_ROLE_FETCH_MODE}" == 'git-clone' ]];then
-    pushd playbooks
-      ${ANSIBLE_BINARY} git-clone-repos.yml \
-          -i ${CLONE_DIR}/tests/inventory -e role_file=${ANSIBLE_ROLE_FILE}
-    popd
+    ${ANSIBLE_BINARY} playbooks/git-clone-repos.yml \
+        -i ${CLONE_DIR}/tests/inventory -e role_file=${ANSIBLE_ROLE_FILE}
   else
     echo "Please set the ANSIBLE_ROLE_FETCH_MODE to either of the following options ['galaxy', 'git-clone']"
     exit 99


### PR DESCRIPTION
This patch creates a wrapper "ceph-ansible" that ensures that the
correct Ansible version (and dependencies) can be installed for
ceph-ansible specifically are used.

Additionally, this removes the installation of tox and bindep which
aren't required. Documentation has been updated to reflect this. This
should make it easier for operators since they won't have to load into
the specific venv and can call the correct version using "ceph-ansible"
instead.