### PR TITLE
Adjust path for ceph-ansible binary

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -55,14 +55,12 @@ if [ "${RE_JOB_SCENARIO}" = "functional" ]; then
   export CLONE_DIR="$(pwd)"
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
   export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
-  export ANSIBLE_BINARY="${ANSIBLE_BINARY:-/opt/rpc-ceph_ansible-runtime/bin/ansible-playbook}"
+  export ANSIBLE_BINARY="${ANSIBLE_BINARY:-ceph-ansible}"
   bash scripts/bootstrap-ansible.sh
   # Clone the test repos
-  pushd playbooks
-    ${ANSIBLE_BINARY} git-clone-repos.yml \
-                     -i ${CLONE_DIR}/tests/inventory \
-                     -e role_file=../ansible-role-test-requirements.yml
-  popd
+  ${ANSIBLE_BINARY} playbooks/git-clone-repos.yml \
+                   -i ${CLONE_DIR}/tests/inventory \
+                   -e role_file=../ansible-role-test-requirements.yml
   ${ANSIBLE_BINARY} -i tests/inventory tests/setup-ceph-aio.yml -e @tests/test-vars.yml
   # Use the rpc-maas deploy to test MaaS
   if [ "${IRR_CONTEXT}" != "ceph" ]; then


### PR DESCRIPTION
The {post,pre}_merge_test/run script was referencing the venv for
ceph, we should move it to use the ceph-ansible binary.