### PR TITLE
Bump to use ansible 2.4.2.0

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -2,10 +2,10 @@
   src: https://github.com/ceph/ceph-ansible
   scm: git
   version: v3.0.17
-- name: ../plugins
+- name: ../ceph_plugins
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
   scm: git
-  version: stable/pike
+  version: master
 - name: rsyslog_client
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_client
   scm: git

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,16 +1,10 @@
 [defaults]
 
-library             = /etc/ansible/plugins/library
+library             = /etc/ansible/ceph_plugins/library
 # set plugin path directories here, separate with colons
-action_plugins     = /etc/ansible/plugins/action
-cache_plugins      = /etc/ansible/plugins/cache
-callback_plugins   = /etc/ansible/plugins/callback
-connection_plugins = /etc/ansible/plugins/connection
-lookup_plugins     = /etc/ansible/plugins/lookup
-inventory_plugins  = /etc/ansible/plugins/inventory
-vars_plugins       = /etc/ansible/plugins/vars
-filter_plugins     = /etc/ansible/plugins/filter
-test_plugins       = /etc/ansible/plugins/test
-terminal_plugins   = /etc/ansible/plugins/terminal
-strategy_plugins   = /etc/ansible/plugins/strategy
+action_plugins     = /etc/ansible/ceph_plugins/action
+callback_plugins   = /etc/ansible/ceph_plugins/callback
+connection_plugins = /etc/ansible/ceph_plugins/connection
+filter_plugins     = /etc/ansible/ceph_plugins/filter
+lookup_plugins     = /etc/ansible/ceph_plugins/lookup
 roles_path         = /etc/ansible/roles:/etc/ansible/roles/ceph-ansible/roles/

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -1,6 +1,6 @@
 set -e -u -x
 
-export ANSIBLE_PACKAGE=${ANSIBLE_PACKAGE:-"ansible==2.3.2.0"}
+export ANSIBLE_PACKAGE=${ANSIBLE_PACKAGE:-"ansible==2.4.2.0"}
 export SSH_DIR=${SSH_DIR:-"/root/.ssh"}
 export ANSIBLE_ROLE_FILE=${ANSIBLE_ROLE_FILE:-"ansible-role-requirements.yml"}
 # Set the role fetch mode to any option [galaxy, git-clone]

--- a/tests/inventory
+++ b/tests/inventory
@@ -13,14 +13,14 @@ mgr2
 localhost
 
 [all_containers]
-mon1
-mon2
-osd1
-osd2
-rgw1
-mgr1
-mgr2
-allsvc
+mon1 container_name=mon1 physical_host=localhost
+mon2 container_name=mon2 physical_host=localhost
+osd1 container_name=osd1 physical_host=localhost
+osd2 container_name=osd2 physical_host=localhost
+rgw1 container_name=rgw1 physical_host=localhost
+mgr1 container_name=mgr1 physical_host=localhost
+mgr2 container_name=mgr2 physical_host=localhost
+allsvc container_name=allsvc physical_host=localhost
 
 [rgws]
 rgw1


### PR DESCRIPTION
Ceph-ansible v3+ supports ansible 2.4.2, we should use this by default.