### PR TITLE
Cephstora-16  Overriding some ceph-ansible defaults for RPC

### DIFF
--- a/benchmark/fio_benchmark_setup.yml
+++ b/benchmark/fio_benchmark_setup.yml
@@ -5,7 +5,7 @@
   become: True
   tasks:
     - name: Create fiobench pool
-      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(100) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(100)) }}"
+      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(100) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(5)) }}"
       run_once: True
       when: fiobench_pool_name is not defined
     - name: Create benchmark ceph client

--- a/benchmark/fio_benchmark_setup.yml
+++ b/benchmark/fio_benchmark_setup.yml
@@ -5,7 +5,7 @@
   become: True
   tasks:
     - name: Create fiobench pool
-      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(100) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(5)) }}"
+      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(5) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(5)) }}"
       run_once: True
       when: fiobench_pool_name is not defined
     - name: Create benchmark ceph client

--- a/benchmark/fio_benchmark_setup.yml
+++ b/benchmark/fio_benchmark_setup.yml
@@ -5,7 +5,7 @@
   become: True
   tasks:
     - name: Create fiobench pool
-      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(5) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(5)) }}"
+      command: "ceph osd pool create fiobench {{ fiobench_pgnum | default(128) }} {{ fiobench_pgpnum | default(fiobench_pgnum | default(128)) }}"
       run_once: True
       when: fiobench_pool_name is not defined
     - name: Create benchmark ceph client

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -20,12 +20,35 @@ osd_mkfs_options_xfs: -f -i size=2048
 osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: filestore
 
-radosgw_civetweb_num_threads: 1024
+radosgw_civetweb_num_threads: 4096
 ceph_conf_overrides:
    global:
-     osd_pool_default_pg_num: 32
-     osd_pool_default_pgp_num: 32
+     osd_pool_default_pg_num: 128
+     osd_pool_default_pgp_num: 128
      mon_osd_down_out_interval: 900
+   client:
+     rbd_cache_size: 134217728
+     rbd_cache_max_dirty: 50331648
+     rbd_cache_max_dirty_age: 15
+     rbd_cache_target_dirty: 33554432
+
+os_tuning_params:
+  - { name: kernel.pid_max, value: 4194303 }
+  - { name: fs.file-max, value: 26234859 }
+  - { name: vm.swappiness, value: 10 }
+  - { name: net.ipv4.tcp_tw_recycle, value: 1 }
+  - { name: net.ipv4.tcp_tw_reuse, value: 1 }
+  - { name: net.ipv4.tcp_fin_timeout, value: 10 }
+  - { name: net.ipv4.tcp_slow_start_after_idle, value: 0 }
+  - { name: net.ipv4.tcp_max_syn_backlog, value: 4096 }
+  - { name: net.core.rmem_max, value: 33554432 }
+  - { name: net.core.wmem_max, value: 33554432 }
+  - { name: net.core.rmem_default, value: 33554432 }
+  - { name: net.core.wmem_default, value: 33554432 }
+  - { name: net.core.optmem_max, value: 40960 }
+  - { name: net.ipv4.tcp_rmem, value: 4096 87380 33554432 }
+  - { name: net.ipv4.tcp_wmem, value: 4096 65536 33554432 }
+  - { name: net.netfilter.nf_conntrack_max, value: 1000000 }
 
 disable_transparent_hugepage: false
 containerized_deployment: false

--- a/tests/test-rgw.yml
+++ b/tests/test-rgw.yml
@@ -2,7 +2,7 @@
 - hosts: mons[0]
   tasks:
     - name: Create the scbench pool used in the test
-      shell: ceph osd pool create scbench 100 100
+      shell: ceph osd pool create scbench 5 5
 
     - name: Execute a standard rados bench test and save the output to stdout
       shell: rados bench -p scbench 10 write

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -78,6 +78,8 @@ ceph_mgr_systemd_overrides:
     PrivateDevices: False
 
 ## Testing specific fio_bench vars
+fiobench_pgnum: 5
+fiobench_pgpnum: 5
 fio_direct_read_test_overrides:
   global:
     runtime: 10


### PR DESCRIPTION
Overriding some ceph-ansible defaults to better align the general install scripts with a standard RPC customer environment.   There could be other overrides needed for a customer on case by case bases but these defaults were provided by Support/Development.   