### PR TITLE
[CEPHSTORA-86] Allow defaults to be overridden

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -22,7 +22,7 @@ osd_objectstore: filestore
 
 
 radosgw_civetweb_num_threads: 4096
-ceph_conf_overrides:
+ceph_conf_overrides_all:
    global:
      osd_pool_default_pg_num: 128
      osd_pool_default_pgp_num: 128
@@ -33,6 +33,13 @@ ceph_conf_overrides:
      rbd_cache_max_dirty: 50331648
      rbd_cache_max_dirty_age: 15
      rbd_cache_target_dirty: 33554432
+
+ceph_conf_overrides_extra: {}
+# This allows us to have ceph_conf_overrides per group without overwriting the
+# overall ceph_conf_overrides_all (above).
+# Additionally, we can set extras as a variable override without having to
+# respecify all the above settings.
+ceph_conf_overrides: "{{ ceph_conf_overrides_all | combine(ceph_conf_overrides_extra, recursive = True) }}"
 
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -105,6 +105,11 @@ fio_test_file_write_overrides:
 # NB if you change the size you will need to change the osd_journal_size
 # We setup 3 osds + 1 journal per host, there are 3 hosts.
 rpc_ceph_test_osd_size: 3G
+# Small test cluster we should set the default pg_num & pgp_num to 32
+ceph_conf_overrides_extra:
+   global:
+     osd_pool_default_pg_num: 32
+     osd_pool_default_pgp_num: 32
 # We don't have enough space in an AIO to run 20GB journal devices
 journal_size: 1024
 monitor_interface: eth1


### PR DESCRIPTION
We need to set the default pg num and pgp num down from 128 for testing,
128 creates pools that are too big and causes ceph radosgw to not start.

To do this properly this patch sets up a "ceph_conf_overrides_extra"
variable that is combined with ceph_conf_overrides_all to allow
additional settings to be specified that will overwrite the existing
ones in group_vars, but still use settings that aren't specifically
overwritten.

This saves the deployer having to completely respecify the var including
all defaults that they may not want to change at all.