### PR TITLE
Pause before setting up logging

### DIFF
--- a/playbooks/ceph-setup-logging.yml
+++ b/playbooks/ceph-setup-logging.yml
@@ -1,6 +1,11 @@
 # Setup rsyslog logging
 - hosts: mons:osds:rgws:mgrs
   become: True
+  pre_tasks:
+    - name: Pause to allow services to restart
+      pause:
+        seconds: 10
+        prompt: "Waiting for Ceph services to start appropriately"
   post_tasks:
     - name: Configure syslog user in Ceph group
       user:

--- a/playbooks/deploy-ceph.yml
+++ b/playbooks/deploy-ceph.yml
@@ -151,8 +151,9 @@
     - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-iscsi-gw, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
-# Setup logging to centralized rsyslog server
-- include: ceph-setup-logging.yml
 # Setup Ceph RGW Endpoint if keystone is available
 - include: ceph-keystone-rgw.yml
   when: radosgw_keystone | bool
+
+# Setup logging to centralized rsyslog server
+- include: ceph-setup-logging.yml


### PR DESCRIPTION
The logging role doesn't continue to update logs that are shipped, this
causes issues when the role is run but services haven't started properly
yet.

This PR adds a pause in that will wait for 10 seconds to allow the
services some time to start up.

This should hopefully alleviate some of the logging test isues we've
seen in the gate.