### PR TITLE
Default radosgw_keystone_ssl to false

### DIFF
--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -67,6 +67,9 @@ cephx: true
 radosgw_keystone_admin_password:
 
 radosgw_keystone: false
+# We need to default this while until https://github.com/ceph/ceph-ansible/pull/2355 is merged
+# Set to true if using PKI keys
+radosgw_keystone_ssl: false
 
 radosgw_service_publicurl: "https://{{ external_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
 radosgw_service_adminurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"

--- a/tests/test-vars-rgw.yml
+++ b/tests/test-vars-rgw.yml
@@ -2,7 +2,6 @@
 ### Keystone RGW Integration vars
 # convert these to lookups
 radosgw_keystone: true
-radosgw_keystone_ssl: false
 service_region: RegionOne
 radosgw_keystone_admin_password: testpass
 keystone_admin_user_name: admin


### PR DESCRIPTION
Ceph-ansible currently doesn't default the radosgw_keystone_ssl value,
we should default this to false. Until
https://github.com/ceph/ceph-ansible/pull/2355 merges.