### PR TITLE
CEPHSTORA-92 Running benchmarks needs reference to group_vars

### DIFF
--- a/benchmark/group_vars
+++ b/benchmark/group_vars
@@ -1,0 +1,1 @@
+../playbooks/group_vars/


### PR DESCRIPTION
Using anisble to run the fio benchmarks requires access to the group vars since those .yml files have been separated out of the playbooks dir