### PR TITLE
RE-1276 Fix testing rpc-ceph with rpc-maas

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Otherwise just use ``./run_tests.sh`` to build the AIO.
 ```bash
 export PUBCLOUD_USERNAME=<username>
 export PUBCLOUD_API_KEY=<api_key>
-export IRR_CONTEXT=master
 ```
 
 ### Tested builds as AIO

--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -24,7 +24,8 @@ export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-"functional"}
 export RE_JOB_BRANCH=${RE_JOB_BRANCH:-"master"}
 export RPC_MAAS_DIR=${RPC_MAAS_DIR:-/etc/ansible/roles/rpc-maas}
 # NOTE(mattt): This is a legacy variable which is still used by rpc-maas
-export IRR_CONTEXT=${RE_JOB_BRANCH}
+export IRR_CONTEXT=${IRR_CONTEXT:-${RE_JOB_BRANCH}}
+export TEST_RPC_MAAS=${TEST_RPC_MAAS:-True}
 
 # Install python2 for Ubuntu 16.04 and CentOS 7
 if which apt-get; then
@@ -71,7 +72,7 @@ if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone
                    -i ${ANSIBLE_INVENTORY} \
                    -e @tests/test-vars.yml
   # Use the rpc-maas deploy to test MaaS
-  if [ "${IRR_CONTEXT}" != "ceph" ]; then
+  if [ "${IRR_CONTEXT}" != "ceph" ] && [ "${TEST_RPC_MAAS}" == "True" ]; then
     pushd ${RPC_MAAS_DIR}
       bash tests/test-ansible-functional.sh
     popd


### PR DESCRIPTION
rpc-maas uses rpc-ceph to test the code related to monitoring a Ceph
deployment. rpc-ceph uses rpc-maas to test that that MaaS monitoring
using the master branch works. When testing the repository rpc-maas, the
MaaS tests run by rpc-ceph need to be disabled. IRR_CONTEXT has been
used to determine if the tests should be run however that is broken in
`gating/pre_merge_test/run` due to it being set to RE_JOB_BRANCH which
is only used in post-merge jobs and because it can't be overridden.

This change fixes the use of IRR_CONTEXT so that it can be set in
rpc-maas and adds a new variable, TEST_RPC_MAAS, that is more
descriptive with regards to its purpose. Once this is merged and
rpc-maas has switched to using TEST_RPC_MAAS, IRR_CONTEXT can be
removed.