### PR TITLE
Adjust order of log configuration

### DIFF
--- a/playbooks/ceph-setup-logging.yml
+++ b/playbooks/ceph-setup-logging.yml
@@ -4,7 +4,7 @@
   pre_tasks:
     - name: Pause to allow services to restart
       pause:
-        seconds: 10
+        seconds: "{{ logging_setup_wait_time | default(1) }}"
         prompt: "Waiting for Ceph services to start appropriately"
   post_tasks:
     - name: Configure syslog user in Ceph group

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -18,9 +18,13 @@
 - include: ../playbooks/deploy-ceph.yml
 - include: ../playbooks/ceph-keystone-rgw.yml
   when: radosgw_keystone | bool
-- include: ../playbooks/ceph-setup-logging.yml
 
 ## Tests
 - include: test-rgw.yml
-- include: test-logging.yml
 - include: ../benchmark/fio_benchmark.yml
+
+## Logging setup and tests
+# This is done after to allow time for the logs
+# to exist.
+- include: ../playbooks/ceph-setup-logging.yml
+- include: test-logging.yml


### PR DESCRIPTION
Sometimes the tests fail because the services haven't created their logs
yet, and so they don't exist when tested.

We should change the order so that we run the benchmark and RGW tests
before we setup the logging to allow additional time for the logging to
be setup.