### PR TITLE
CEPHSTORA-99 Fix MaaS integration

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -69,8 +69,9 @@ if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone
                    -i ${ANSIBLE_INVENTORY} \
                    -e @tests/test-vars.yml
   # Use the rpc-maas deploy to test MaaS
-  if [ "${TEST_RPC_MAAS}" != "False" ]; then
+  if [ "${TEST_RPC_MAAS}" != "False" ] && [ "${RE_JOB_SCENARIO}" != "keystone_rgw" ]; then
     pushd ${RPC_MAAS_DIR}
+      export RE_JOB_SCENARIO="ceph"
       bash tests/test-ansible-functional.sh
     popd
   fi


### PR DESCRIPTION
Since the IRR changes were removed MaaS tests only work from the MaaS
side. This is because the RE_JOB_SCENARIO for ceph tests is "functional"
and not "ceph".

We can work around this by setting the TEST_PLAYBOOK var to be tests.yml
manually instead of relying on the if statement inside the maas scripts.