### PR TITLE
CEPHSTORA-102 Match networking and container settings to RPC-O

### DIFF
--- a/tests/host_vars/allsvc.yml
+++ b/tests/host_vars/allsvc.yml
@@ -1,16 +1,16 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.103"
-ceph_storage_address: "{{ storage_addr_prefix }}.103"
+ansible_host: "{{ ansible_addr_prefix }}.33"
+ceph_storage_address: "{{ storage_addr_prefix }}.33"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
     interface: "eth2"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/host_vars/keystone1.yml
+++ b/tests/host_vars/keystone1.yml
@@ -1,10 +1,10 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.107"
+ansible_host: "{{ ansible_addr_prefix }}.37"
 container_address: "{{ ansible_host }}"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/host_vars/localhost.yml
+++ b/tests/host_vars/localhost.yml
@@ -1,4 +1,5 @@
 ---
-ansible_host: "10.1.1.1"
+
+ansible_host: "172.29.236.100"
 ansible_connection: local
 ansible_python_interpreter: "/usr/bin/python2"

--- a/tests/host_vars/mon1.yml
+++ b/tests/host_vars/mon1.yml
@@ -1,16 +1,16 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.101"
-ceph_storage_address: "{{ storage_addr_prefix }}.101"
+ansible_host: "{{ ansible_addr_prefix }}.31"
+ceph_storage_address: "{{ storage_addr_prefix }}.31"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
     interface: "eth2"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/host_vars/mon2.yml
+++ b/tests/host_vars/mon2.yml
@@ -1,16 +1,16 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.102"
-ceph_storage_address: "{{ storage_addr_prefix }}.102"
+ansible_host: "{{ ansible_addr_prefix }}.32"
+ceph_storage_address: "{{ storage_addr_prefix }}.32"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
     interface: "eth2"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/host_vars/osd1.yml
+++ b/tests/host_vars/osd1.yml
@@ -1,16 +1,16 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.104"
-ceph_storage_address: "{{ storage_addr_prefix }}.104"
+ansible_host: "{{ ansible_addr_prefix }}.34"
+ceph_storage_address: "{{ storage_addr_prefix }}.34"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
     interface: "eth2"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/host_vars/rgw1.yml
+++ b/tests/host_vars/rgw1.yml
@@ -1,16 +1,16 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.106"
-ceph_storage_address: "{{ storage_addr_prefix }}.106"
+ansible_host: "{{ ansible_addr_prefix }}.36"
+ceph_storage_address: "{{ storage_addr_prefix }}.36"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
     interface: "eth2"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/host_vars/rsyslog1.yml
+++ b/tests/host_vars/rsyslog1.yml
@@ -1,9 +1,9 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.110"
+ansible_host: "{{ ansible_addr_prefix }}.40"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"

--- a/tests/test-vars-rgw.yml
+++ b/tests/test-vars-rgw.yml
@@ -10,8 +10,8 @@ keystone_admin_tenant_name: admin
 keystone_service_adminuri_insecure: false
 
 ### HAproxy Vars
-external_lb_vip_address: 10.1.1.1
-internal_lb_vip_address: 10.1.1.1
+external_lb_vip_address: "{{ bootstrap_host_public_address | default(ansible_default_ipv4.address) }}"
+internal_lb_vip_address: 172.29.236.100
 haproxy_default_services:
   - service:
       haproxy_service_name: galera

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -1,20 +1,19 @@
 ---
 force_containers_destroy: True
 force_containers_data_destroy: False
-ansible_addr_prefix: "10.1.1"
-storage_addr_prefix: "10.2.1"
+ansible_addr_prefix: "172.29.236"
+storage_addr_prefix: "172.29.244"
+bridges:
+  - name: "br-mgmt"
+    ip_addr: "{{ ansible_addr_prefix }}.100"
+  - name: "br-storage"
+    ip_addr: "{{ storage_addr_prefix }}.100"
 container_name: "{{ inventory_hostname }}"
 physical_host: localhost
 properties:
   service_name: "{{ inventory_hostname }}"
 ansible_become: True
 ansible_user: root
-bridges:
-  - name: "br-mgmt"
-    ip_addr: "{{ ansible_addr_prefix }}.1"
-  - name: "br-storage"
-    ip_addr: "{{ storage_addr_prefix }}.1"
-
 
 ## LXC container default bind mounts
 lxc_container_default_bind_mounts:
@@ -30,9 +29,11 @@ lxc_container_wait_params:
   timeout: 60
 
 # LXC Settings
-lxc_net_address: 10.100.100.1
+lxc_net_address: 10.255.255.1
+lxc_net_dhcp_range: 10.255.255.2,10.255.255.253
 lxc_net_netmask: 255.255.255.0
-lxc_net_dhcp_range: 10.100.100.2,10.100.100.99
+lxc_image_cache_server: rpc-repo.rackspace.com
+lxc_container_backing_store: overlayfs
 lxc_net_bridge: lxcbr0
 lxc_kernel_options:
   - { key: 'fs.inotify.max_user_instances', value: 1024 }
@@ -113,8 +114,8 @@ ceph_conf_overrides_extra:
 # We don't have enough space in an AIO to run 20GB journal devices
 journal_size: 1024
 monitor_interface: eth1
-public_network: 10.1.1.0/24
-cluster_network: 10.2.1.0/24
+public_network: 172.29.236.0/22
+cluster_network: 172.29.244.0/22
 osd_scenario: non-collocated
 devices:
   - /dev/sda


### PR DESCRIPTION
In order to create an automated and integrated AIO we need to ensure the
RPC-Ceph builds are running on the same network range as the RPC-O
deploys, and that the container settings match.

This PR adjusts those settings.