### PR TITLE
CEPHSTORA-105 Setup HAProxy outside of testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The inventory should consist of the following:
    * ``ceph-ansible``
    * ``rsyslog_client``
    * ``openstack-ansible-plugins`` (``ceph-ansible`` uses the config template plugin from here).
+   * ``haproxy_server``
 
 7. Run the ``ceph-ansible`` playbook from the playbooks directory:
 
@@ -99,6 +100,7 @@ The inventory should consist of the following:
 
    * ``ceph-setup-logging.yml``will setup rsyslog client, ensure you have the appropriate rsyslog server setup, or other log shipping location, refer to: https://docs.openstack.org/openstack-ansible-rsyslog_client/latest/ for more details
    * ``ceph-keystone-rgw.yml`` will setup required keystone users and endpoints for Ceph.
+   * ``ceph-rgw-haproxy.yml`` will setup the HAProxy VIP for Ceph Rados GW. Ensure you specify ``haproxy_all`` group in your inventory with the HAProxy hosts.
 
 Your deployment should be successful.
 

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -10,3 +10,7 @@
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_client
   version: stable/pike
+- name: haproxy_server
+  src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
+  scm: git
+  version: stable/pike

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,4 +13,4 @@ filter_plugins     = /etc/ansible/ceph_plugins/filter
 test_plugins       = /etc/ansible/ceph_plugins/test
 terminal_plugins   = /etc/ansible/ceph_plugins/terminal
 strategy_plugins   = /etc/ansible/ceph_plugins/strategy
-roles_path         = /etc/ansible/roles:/etc/ansible/roles/ceph-ansible/roles/
+roles_path         = /etc/ansible/ceph_roles/ceph-ansible/roles:/etc/ansible/ceph_roles:/etc/ansible/roles

--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -21,7 +21,7 @@ env
 echo "+-------------------- START ENV VARS --------------------+"
 
 export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-"functional"}
-export RPC_MAAS_DIR=${RPC_MAAS_DIR:-/etc/ansible/roles/rpc-maas}
+export RPC_MAAS_DIR=${RPC_MAAS_DIR:-/etc/ansible/ceph_roles/rpc-maas}
 export TEST_RPC_MAAS=${TEST_RPC_MAAS:-True}
 
 # Install python2 for Ubuntu 16.04 and CentOS 7

--- a/playbooks/ceph-rgw-haproxy.yml
+++ b/playbooks/ceph-rgw-haproxy.yml
@@ -20,5 +20,3 @@
   roles:
     - role: "haproxy_server"
       haproxy_service_configs: "{{ haproxy_default_services | default([]) }}"
-  vars_files:
-    - test-vars.yml

--- a/playbooks/git-clone-repos.yml
+++ b/playbooks/git-clone-repos.yml
@@ -8,7 +8,7 @@
   - name: Clone git repos
     git:
       repo: "{{ item.src }}"
-      dest: "/etc/ansible/roles/{{ item.name }}"
+      dest: "/etc/ansible/ceph_roles/{{ item.name }}"
       version: "{{ item.version }}"
       refspec: "{{ item.refspec | default(omit) }}"
       update: true

--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -77,3 +77,13 @@ radosgw_keystone_ssl: false
 radosgw_service_publicurl: "https://{{ external_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
 radosgw_service_adminurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
 radosgw_service_internalurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
+
+## RadosGW VIP for HAProxy
+haproxy_default_services:
+  - service:
+      haproxy_service_name: ceph_rgw
+      haproxy_backend_nodes: "{{ groups['rgws'] | default([]) }}"
+      haproxy_port: 8080
+      haproxy_balance_type: "http"
+      haproxy_backend_options:
+        - "httpchk HEAD /"

--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -38,10 +38,6 @@
   src: https://git.openstack.org/openstack/openstack-ansible-galera_server
   scm: git
   version: stable/pike
-- name: haproxy_server
-  src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
-  scm: git
-  version: stable/pike
 - name: rabbitmq_server
   src: https://git.openstack.org/openstack/openstack-ansible-rabbitmq_server
   scm: git

--- a/tests/inventory
+++ b/tests/inventory
@@ -6,6 +6,7 @@ osd1
 osd2
 allsvc
 rgw1
+rsyslog1
 
 [hosts]
 localhost
@@ -17,6 +18,7 @@ osd1
 osd2
 rgw1
 allsvc
+rsyslog1
 
 [rgws]
 rgw1
@@ -38,7 +40,10 @@ mon2
 allsvc
 
 [rsyslog_all]
-localhost
+rsyslog1
 
 [benchmark_hosts]
+localhost
+
+[haproxy_all]
 localhost

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -5,8 +5,7 @@
 
 ## Setup non-ceph components for testing
 - include: setup-rsyslog-server.yml
-- include: test-install-haproxy.yml
-  when: radosgw_keystone | bool
+- include: ../playbooks/ceph-rgw-haproxy.yml
 - include: common/test-install-infra.yml
   when: radosgw_keystone | bool
 - include: common/test-install-keystone.yml

--- a/tests/test-vars-rgw.yml
+++ b/tests/test-vars-rgw.yml
@@ -10,8 +10,6 @@ keystone_admin_tenant_name: admin
 keystone_service_adminuri_insecure: false
 
 ### HAproxy Vars
-external_lb_vip_address: "{{ bootstrap_host_public_address | default(ansible_default_ipv4.address) }}"
-internal_lb_vip_address: 172.29.236.100
 haproxy_default_services:
   - service:
       haproxy_service_name: galera

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -14,6 +14,8 @@ properties:
   service_name: "{{ inventory_hostname }}"
 ansible_become: True
 ansible_user: root
+external_lb_vip_address: "{{ bootstrap_host_public_address | default(ansible_default_ipv4.address) }}"
+internal_lb_vip_address: 172.29.236.100
 
 ## LXC container default bind mounts
 lxc_container_default_bind_mounts:


### PR DESCRIPTION
We should setup haproxy when the haproxy_all host group is specified,
and when rados gw hosts exist. This shouldn't be determined by the
OpenStack integration, and Ceph should manage it's own VIP.

This PR moves the playbook into "playbooks" dir and makes adjustments to
the role-requirements, group_vars defaults, README and base inventory
for testing.

Additionally, to ensure roles/plugins for the Ceph roles, that would
overlap with any existing deploys - we should name space the roles,
e.g. use "ceph_roles". This will mean that issues don't arise as a
result of other deployments using the same roles and overwriting the
existing Ceph roles.