### PR TITLE
Fix Addr for osd2 host in gating

### DIFF
--- a/tests/host_vars/osd2.yml
+++ b/tests/host_vars/osd2.yml
@@ -1,6 +1,6 @@
 ---
-ansible_host: "{{ ansible_addr_prefix }}.105"
-ceph_storage_address: "{{ storage_addr_prefix }}.105"
+ansible_host: "{{ ansible_addr_prefix }}.35"
+ceph_storage_address: "{{ storage_addr_prefix }}.35"
 container_networks:
   management_address:
     address: "{{ ansible_host }}"


### PR DESCRIPTION
This host was missed off when the addresses were changed to match up
with the existing RPC-O AIO.

This PR fixes that.