### PR TITLE
[WIP] nSpawn container test

### DIFF
--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -1,11 +1,3 @@
-- name: lxc_hosts
-  src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
-  scm: git
-  version: stable/pike
-- name: lxc_container_create
-  src: https://git.openstack.org/openstack/openstack-ansible-lxc_container_create
-  scm: git
-  version: stable/pike
 - name: apt_package_pinning
   src: https://git.openstack.org/openstack/openstack-ansible-apt_package_pinning
   scm: git
@@ -50,3 +42,11 @@
   src: https://git.openstack.org/openstack/openstack-ansible-memcached_server
   scm: git
   version: stable/pike
+- name: nspawn_container_create
+  src: https://github.com/openstack/openstack-ansible-nspawn_container_create
+  scm: git
+  version: master
+- name: nspawn_host
+  src: https://github.com/openstack/openstack-ansible-nspawn_hosts
+  scm: git
+  version: master

--- a/tests/build-containers.yml
+++ b/tests/build-containers.yml
@@ -1,24 +1,28 @@
-- name: Gather facts for the LXC hosts
-  hosts: localhost
-  become: true
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather nspawn container host facts
+  hosts: "{{ nspawn_host_group | default('hosts') }}"
   gather_facts: true
 
-- include: destroy_containers.yml
-  when: destroy_first | default(True) | bool
-
-- name: Playbook for creating containers
+- name: Create container(s)
   hosts: all_containers
-  become: True
-  gather_facts: False
-  any_errors_fatal: true
+  gather_facts: false
+  user: root
   roles:
-    - role: "lxc_container_create"
-  post_tasks:
-    - name: Wait for container connectivity
-      wait_for_connection:
-        connect_timeout: "{{ lxc_container_wait_params.connect_timeout | default(omit) }}"
-        delay: "{{ lxc_container_wait_params.delay | default(omit) }}"
-        sleep: "{{ lxc_container_wait_params.sleep | default(omit) }}"
-        timeout: "{{ lxc_container_wait_params.timeout | default(omit) }}"
-  vars_files:
-    - test-vars.yml
+    - role: "nspawn_container_create"
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  tags:
+    - nspawn-containers-create

--- a/tests/host_vars/allsvc.yml
+++ b/tests/host_vars/allsvc.yml
@@ -5,12 +5,6 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
-    interface: "eth2"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/host_vars/keystone1.yml
+++ b/tests/host_vars/keystone1.yml
@@ -5,6 +5,3 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/host_vars/localhost.yml
+++ b/tests/host_vars/localhost.yml
@@ -1,5 +1,9 @@
 ---
-
 ansible_host: "172.29.236.100"
 ansible_connection: local
 ansible_python_interpreter: "/usr/bin/python2"
+container_networks:
+  storage_address:
+    bridge: "br-storage"
+  mgmt_address:
+    bridge: "br-mgmt"

--- a/tests/host_vars/mon1.yml
+++ b/tests/host_vars/mon1.yml
@@ -5,12 +5,6 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
-    interface: "eth2"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/host_vars/mon2.yml
+++ b/tests/host_vars/mon2.yml
@@ -5,12 +5,6 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
-    interface: "eth2"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/host_vars/osd1.yml
+++ b/tests/host_vars/osd1.yml
@@ -5,12 +5,6 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
-    interface: "eth2"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/host_vars/osd2.yml
+++ b/tests/host_vars/osd2.yml
@@ -5,12 +5,6 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.255.0"
-    type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
-    interface: "eth2"
-    netmask: "255.255.255.0"
-    type: "veth"

--- a/tests/host_vars/rgw1.yml
+++ b/tests/host_vars/rgw1.yml
@@ -5,12 +5,6 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
-    interface: "eth2"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/host_vars/rsyslog1.yml
+++ b/tests/host_vars/rsyslog1.yml
@@ -4,6 +4,3 @@ container_networks:
   management_address:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
-    interface: "eth1"
-    netmask: "255.255.252.0"
-    type: "veth"

--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -20,6 +20,9 @@
       use: "{{ ansible_pkg_mgr }}"
     delegate_to: "{{ physical_host }}"
     run_once: True
+  - name: Ensure apt cache is updated
+    apt:
+      update_cache: true
   - name: Ensure xfsprogs is installed on containers
     package:
       name: xfsprogs

--- a/tests/setup-containers.yml
+++ b/tests/setup-containers.yml
@@ -1,13 +1,20 @@
 ---
 - name: Playbook for configuring the LXC host
-  hosts: lxc_hosts
   become: true
+  hosts: "{{ nspawn_host_group | default('hosts') }}"
+  gather_facts: true
+  user: root
   roles:
-    - role: "lxc_hosts"
-      lxc_net_address: 10.100.100.1
-      lxc_net_dhcp_range: 10.100.100.8,10.100.100.253
-      lxc_net_bridge: lxcbr0
-  post_tasks:
+    - role: "nspawn_host"
+  environment: "{{ deployment_environment_variables | default({}) }}"
+  tags:
+    - nspawn-hosts
+  pre_tasks:
+    - name: Install bridge-utils
+      package:
+        name: bridge-utils
+        state: present
+        use: "{{ ansible_pkg_mgr }}"
     - name: Ensure that /etc/network/interfaces.d/ exists (Debian)
       file:
         path: /etc/network/interfaces.d/
@@ -156,7 +163,5 @@
     - name: Add iptables rule to provide internet connectivity to instances
       command: "{{ _iptables_path.stdout }} -t nat -A POSTROUTING -o eth0 -j MASQUERADE"
 
-    - name: Add iptables rules for lxc natting
-      command: /usr/local/bin/lxc-system-manage iptables-create
   vars_files:
     - test-vars.yml

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -16,29 +16,7 @@ ansible_become: True
 ansible_user: root
 external_lb_vip_address: "{{ bootstrap_host_public_address | default(ansible_default_ipv4.address) }}"
 internal_lb_vip_address: 172.29.236.100
-
-## LXC container default bind mounts
-lxc_container_default_bind_mounts:
-  - host_directory: "/openstack/backup/{{ inventory_hostname }}"
-    container_directory: "/var/backup"
-  - host_directory: "/openstack/log/{{ inventory_hostname }}"
-    container_directory: "/var/log"
-
-lxc_container_wait_params:
-  # Wait 3 seconds before attempting the first connection
-  delay: 3
-  # Wait 60 seconds for the container to respond
-  timeout: 60
-
-# LXC Settings
-lxc_net_address: 10.255.255.1
-lxc_net_dhcp_range: 10.255.255.2,10.255.255.253
-lxc_net_netmask: 255.255.255.0
-lxc_image_cache_server: rpc-repo.rackspace.com
-lxc_container_backing_store: dir
-lxc_net_bridge: lxcbr0
-lxc_kernel_options:
-  - { key: 'fs.inotify.max_user_instances', value: 1024 }
+container_tech: "nspawn"
 
 ansible_ssh_extra_args: >
   -o UserKnownHostsFile=/dev/null


### PR DESCRIPTION
The lxc containers we're using make attaching drives that will work with
Ceph hard.

This is an initial exploration into using nSpawn containers which are
closer to a "chroot" and should allow us to setup the storage easier for
Ceph purposes.