### PR TITLE
CEPHSTORA-115   HotFix to repair broken link

### DIFF
--- a/docs/rpc-ceph-install.md
+++ b/docs/rpc-ceph-install.md
@@ -300,8 +300,7 @@ openstack_config: false
 ## Ceph Integration with RPC OpenStack(RPCO)
 
 Current documentation of the Integration pieces of Ceph and OpenStack 
-https://github.com/rsoprivatecloud/rpc-deployments/blob/master/installs/newton/RPCO_Ceph-Ansible_install.md
- 
+https://github.com/rsoprivatecloud/rpc-deployments/blob/master/installs/ceph/RPCO_Ceph-Ansible_install.md 
 
 ## Integration of Ceph Object Storage (RGW) with OpenStack
 Information on setting up RGW with RPC Openstack can be found here:


### PR DESCRIPTION
A link in the install documentation was moved:

installs/newton/RPCO_Ceph-Ansible_install.md → installs/ceph/RPCO_Ceph-Ansible_install.md