### PR TITLE
CEPHSTORA-103 Retry log checks until success

### DIFF
--- a/tests/test-logging.yml
+++ b/tests/test-logging.yml
@@ -6,7 +6,9 @@
        path: "/var/log/rsyslog/{{ container_name }}/ceph-mon.{{ container_name }}.log"
      delegate_to: "{{ groups['rsyslog_all'][0] }}"
      register: ceph_mon_log
-     failed_when: ceph_mon_log.stat.isreg == False
+     until: (ceph_mon_log.stat.isreg is defined) and (ceph_mon_log.stat.isreg == True)
+     retries: 10
+     delay: 2
 
 - hosts: rgws
   tasks:
@@ -15,7 +17,9 @@
        path: "/var/log/rsyslog/{{ container_name }}/ceph-rgw-{{ container_name }}.log"
      delegate_to: "{{ groups['rsyslog_all'][0] }}"
      register: ceph_rgw_log
-     failed_when: ceph_rgw_log.stat.isreg == False
+     until: (ceph_rgw_log.stat.isreg is defined) and (ceph_rgw_log.stat.isreg == True)
+     retries: 10
+     delay: 2
 
 - hosts: mgrs
   tasks:
@@ -24,7 +28,9 @@
        path: "/var/log/rsyslog/{{ container_name }}/ceph-mgr.{{ container_name }}.log"
      delegate_to: "{{ groups['rsyslog_all'][0] }}"
      register: ceph_mgr_log
-     failed_when: ceph_mgr_log.stat.isreg == False
+     until: (ceph_mgr_log.stat.isreg is defined) and (ceph_mgr_log.stat.isreg == True)
+     retries: 10
+     delay: 2
 
 - hosts: osds
   tasks:
@@ -33,4 +39,6 @@
      delegate_to: "{{ groups['rsyslog_all'][0] }}"
      register: ceph_osd_log
      changed_when: False
-     failed_when: (ceph_osd_log.stdout | int) != (devices | length)
+     until: (ceph_osd_log.stdout | int) == (devices | length)
+     retries: 10
+     delay: 2


### PR DESCRIPTION
Our logging test is flakey, in manual testing I've seen this issue once,
and the log did exist - so adding a retry to try and reduce the number
of failed gates we see as a result of the logging problem.