### PR TITLE
CEPHSTORA-118 Set application for rpc-ceph created pools

### DIFF
--- a/benchmark/fio_benchmark_setup.yml
+++ b/benchmark/fio_benchmark_setup.yml
@@ -10,8 +10,11 @@
       when: fiobench_pool_name is not defined
     - name: Create benchmark ceph client
       command: "ceph auth get-or-create client.fiobench mon 'allow r' osd 'allow * pool={{ fiobench_pool_name | default('fiobench') }}'"
-      when: inventory_hostname == groups['mons'][0]
+      run_once: True
       register: _ceph_benchmark_client
+    - name: Set application for benchmark pool
+      command: "ceph osd pool application enable {{ fiobench_pool_name | default('fiobench') }} rbd"
+      run_once: True
     - name: Set benchmark_client fact
       set_fact:
         ceph_benchmark_client: "{{ _ceph_benchmark_client }}"

--- a/tests/test-rgw.yml
+++ b/tests/test-rgw.yml
@@ -17,6 +17,9 @@
     - name: Create the scbench pool used in the test
       shell: ceph osd pool create scbench 5 5
 
+    - name: Set pool application
+      command: "ceph osd pool application enable scbench rbd"
+
     - name: Execute a standard rados bench test and save the output to stdout
       shell: rados bench -p scbench 10 write
       register: out


### PR DESCRIPTION
For the pools we create as part of RPC-Ceph testing/benchmarking we
should ensure the correct application is set.

This will prevent WARN messages that would generate alerts/tickets when
running benchmarking on customer environments.