### PR TITLE
[DNM] TEST MaaS verify after CEPHSTORA-123 fix

### DIFF
--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -15,9 +15,9 @@
   scm: git
   version: stable/pike
 - name: rpc-maas
-  src: https://github.com/rcbops/rpc-maas
+  src: https://github.com/andymcc/rpc-maas
   scm: git
-  version: master
+  version: ceph_rgw_fix
 - name: os_keystone
   src: https://git.openstack.org/openstack/openstack-ansible-os_keystone
   scm: git

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -128,8 +128,15 @@ dedicated_devices:
   - /dev/sdc
 
 ### MaaS settings
-# Enable the API usage
+# Enable the API usage and verification steps
 maas_use_api: true
+maas_verify_status: true
+maas_verify_registration: true
+maas_excluded_checks: []
+maas_check_period_override:
+  disk_utilisation: 900
+maas_excluded_alarms: []
+maas_rally_enabled: false
 # Will restart the agent service ONLY once at the end of a site.yml run
 maas_restart_independent: false
 # Set the default notification plan, in the gate this is set here


### PR DESCRIPTION
Don't merge this, this is simply a test to show that the verify should
work with the rpc-maas change in CEPHSTORA-123.

Once CEPHSTORA-123 merges we should recheck and merge CEPHSTORA-117
instead of this.