### PR TITLE
CEPHSTORA-114 Bump ceph-ansible to v3.0.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ versions of ``ceph-ansible`` used in RPC deployments.
 
 ## Current versions of ceph-ansible & Ansible
 
-### **ceph-ansible version:** v3.0.22
+### **ceph-ansible version:** v3.0.25
 
 ### **Ansible version:** 2.4.3
 

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,7 +1,7 @@
 - name: ceph-ansible
   scm: git
   src: https://github.com/ceph/ceph-ansible
-  version: v3.0.22
+  version: v3.0.25
 - name: ../ceph_plugins
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
@@ -11,10 +11,10 @@
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_client
   version: stable/pike
 - name: haproxy_server
-  src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
   scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
   version: stable/pike
 - name: rsyslog_server
-  src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_server
   scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_server
   version: stable/pike

--- a/playbooks/group_vars/osds/osds.yml.sample
+++ b/playbooks/group_vars/osds/osds.yml.sample
@@ -230,7 +230,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-#ceph_osd_docker_memory_limit: 1g
+#ceph_osd_docker_memory_limit: 3g
 #ceph_osd_docker_cpu_limit: 1
 
 # PREPARE DEVICE


### PR DESCRIPTION
The fix to ensure application types are set on OpenStack pools has been
merged and backported into v3.0, with the new tag v3.0.25. This will
ensure we stop receiving false WARNING messages for our ceph mon checks
in MaaS.