### PR TITLE
CEPHSTORA-82 Use dir instead of overlayfs

### DIFF
--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -35,7 +35,7 @@ lxc_net_address: 10.255.255.1
 lxc_net_dhcp_range: 10.255.255.2,10.255.255.253
 lxc_net_netmask: 255.255.255.0
 lxc_image_cache_server: rpc-repo.rackspace.com
-lxc_container_backing_store: overlayfs
+lxc_container_backing_store: dir
 lxc_net_bridge: lxcbr0
 lxc_kernel_options:
   - { key: 'fs.inotify.max_user_instances', value: 1024 }


### PR DESCRIPTION
A bug in the way apparmor and overlayfs work together, that exists in
16.04 means that redeploying on the same host will fail if we use
overlayfs.

We should default to use dir as the backend store for containers.