### PR TITLE
CEPHSTORA-28  Adding in an rgw benchmark using the hummingbird bench tool

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -33,7 +33,7 @@ fio_test_file_write - fio_test_file_write_overrides
 ### Running tests
 There are 5 test scenarios based on the document linked above. These are
 meant to represent tests for SSDs and SATA devices. By default all 5 tests will
-run in serial, and output logs to /opt/ceph_fiobench/<test>.<timestamp>.log.
+run in serial, and output logs to /opt/ceph_bench/<test>.<timestamp>.log.
 This means multiple test runs will generate multiple logs. Additionally, the log
 will store an output of "fio --version" as well as the config used in the test.
 If you would like to run only the sata tests set "ssd_bench=False", or for only
@@ -51,3 +51,85 @@ fio_test_file_write
 ### Cleaning up a deploy
 The cleanup script will unmount, unmap and remove the rbd image, as well as
 delete the fiobench pool if "fiobench_pool_name" is not specified.
+
+## rpc-ceph Rados Gateway benchmarking
+A set of playbooks to setup and configure a Rados Object Gateway benchmark run.
+Run the rgw_benchmark.yml to setup, run and cleanup the software and configurations,
+ceph users, and capture the results. Add the "benchmark_hosts" inventory group to specify
+the host on which to run the benchmarks.  The benchmark is also set to delete any objects
+and containers placed into the system.
+
+### Setup the ceph user and subuser
+This benchmark requires a ceph user be created with `radosgw-admin` and a corresponding subuser.
+Both of these users will be removed after the benchmark completes as to not leave any potential 
+security issues.    The user creatd is *testuser* and the subuser will be *testuser:swift*.
+
+### Setting up the software and general config
+The software used for this benchmark is the *bench* command of the *hummingbird* go binary and 
+the configuration file is made from the template  **benchmark/templates/rgw_benchmark_test.conf**
+
+### Benchmark configuration options
+The parameters you can adjust are concurrency, size of put object, number of objects added 
+and number of get requests.  The tool deletes all put objects as a final step.
+
+* bench_rgw_concurrency:  number of concurrent operations
+* bench_rgw_object_size:   size of the object in bytes used in the benchmark 
+* bench_rgw_number_of_objects:  number of objects placed in the system 
+* bench_rgw_number_of_gets: number of get requests performed
+
+When choosing the concurrency setting keep in mind the network throughput available on the client boxes. 
+When choosing the object size and number settings keep in mind that multiple replicas of the object will 
+written into the system so check the clusters available space.   
+
+### Running the benchmark
+The time it takes to run the benchmark will depend on the size and number of objects selected, 
+and it will output logs to */opt/ceph_bench/logs/rgw_benchmark_test.conf.<timestamp>.log*
+Besides the normal results the log will store an output of "hummingbird version" as well as the config used.
+Currently this benchmark is set up to run automatically in creation of a CephAIO but if
+you would like to buy pass the benchmark set `rgw_bench="False"`.   The results will also be
+displayed in the ansible output.
+
+### Sample output
+```
+Humminbird Version: v1.0.0
+
+Bench Config Used:
+[bench]
+auth=http://172.29.236.100:8080/auth/v1.0
+user=testuser:swift
+key=swiftsecret
+concurrency=15 
+object_size=256
+num_objects=5000
+num_gets=10000
+delete = yes
+auth_version=1.0
+policy_name=gold
+
+Hummingbird Benchmark Output:
+Hbird Bench. Concurrency: 15. Object size in bytes: 256
+PUTs: 5000 @ 313.61/s
+  Failures: 0
+  Mean: 0.04777s (210.1% RSD)
+  Median: 0.04019s
+  85%: 0.05609s
+  90%: 0.06067s
+  95%: 0.06743s
+  99%: 0.08686s
+GETs: 10000 @ 2642.35/s
+  Failures: 0
+  Mean: 0.00567s (53.7% RSD)
+  Median: 0.00492s
+  85%: 0.00837s
+  90%: 0.00945s
+  95%: 0.01140s
+  99%: 0.01662s
+DELETEs: 5000 @ 353.94/s
+  Failures: 0
+  Mean: 0.04232s (37.1% RSD)
+  Median: 0.04022s
+  85%: 0.05561s
+  90%: 0.05999s
+  95%: 0.06673s
+  99%: 0.08558s
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -72,6 +72,8 @@ the configuration file is made from the template  **benchmark/templates/rgw_benc
 The parameters you can adjust are concurrency, size of put object, number of objects added 
 and number of get requests.  The tool deletes all put objects as a final step.
 
+* bench_rgw_user_password:  password used by the benchmark
+* bench_rgw_hummingbird_url: url to the benchmarking tool **hummingbird**
 * bench_rgw_concurrency:  number of concurrent operations
 * bench_rgw_object_size:   size of the object in bytes used in the benchmark 
 * bench_rgw_number_of_objects:  number of objects placed in the system 
@@ -80,6 +82,25 @@ and number of get requests.  The tool deletes all put objects as a final step.
 When choosing the concurrency setting keep in mind the network throughput available on the client boxes. 
 When choosing the object size and number settings keep in mind that multiple replicas of the object will 
 written into the system so check the clusters available space.   
+
+### Benchmark Settings for an AIO
+Due the the fact that rpc-ceph tests are run on an AIO the setting placed in **tests/test-vars.yml** are:
+* bench_rgw_concurrency:  15
+* bench_rgw_object_size: 256
+* bench_rgw_number_of_objects: 5000 
+* bench_rgw_number_of_gets: 10000
+
+### Benchmark Settings Defaults
+For the benchmark to be useful on production systems the amount of data written and read needs to be significant.
+So the benchmarks defaults setting are:
+* bench_rgw_concurrency:  50
+* bench_rgw_object_size: 524288 *512k*
+* bench_rgw_number_of_objects: 250000
+* bench_rgw_number_of_gets: 500000
+
+This will write out 128GB of data into the cluster which depending on your replication strategy could end up
+being a lot more. So validate these numbers accordingly. Also keep in mind the size of the clients 
+network connection because if you saturate that link the results of the benchmark will not be accurate.
 
 ### Running the benchmark
 The time it takes to run the benchmark will depend on the size and number of objects selected, 
@@ -96,8 +117,8 @@ Humminbird Version: v1.0.0
 Bench Config Used:
 [bench]
 auth=http://172.29.236.100:8080/auth/v1.0
-user=testuser:swift
-key=swiftsecret
+user=rgwbench:test
+key=rgwbenchsecret
 concurrency=15 
 object_size=256
 num_objects=5000

--- a/benchmark/rgw_benchmark.yml
+++ b/benchmark/rgw_benchmark.yml
@@ -1,0 +1,4 @@
+---
+- include: rgw_benchmark_setup.yml
+- include: rgw_benchmark_run.yml
+- include: rgw_benchmark_cleanup.yml

--- a/benchmark/rgw_benchmark_cleanup.yml
+++ b/benchmark/rgw_benchmark_cleanup.yml
@@ -16,8 +16,6 @@
   become: True
   tasks:
   - name: Remove the subuser of the test user created for benchmark
-    command: "radosgw-admin subuser rm --uid='testuser' --subuser='testuser:swift'"
-    ignore_errors: yes
+    command: "radosgw-admin subuser rm --uid='rgwbench' --subuser='rgwbench:test'"
   - name: Remove test user created for benchmark
-    command: "radosgw-admin user rm --uid='testuser'"
-    ignore_errors: yes
+    command: "radosgw-admin user rm --uid='rgwbench'"

--- a/benchmark/rgw_benchmark_cleanup.yml
+++ b/benchmark/rgw_benchmark_cleanup.yml
@@ -1,0 +1,23 @@
+---
+- hosts: benchmark_hosts
+  become: True
+  tasks:
+  - name: Remove hummingbird software
+    file:
+      state: absent
+      path: "/opt/ceph_bench/hummingbird"
+  - name: Remove remove rgw_bench.conf
+    file:
+      state: absent
+      path: "/opt/ceph_bench/rgw_bench_test.conf"
+
+# Cleanup he user and sub user created for the benchmark
+- hosts: mons[0]
+  become: True
+  tasks:
+  - name: Remove the subuser of the test user created for benchmark
+    command: "radosgw-admin subuser rm --uid='testuser' --subuser='testuser:swift'"
+    ignore_errors: yes
+  - name: Remove test user created for benchmark
+    command: "radosgw-admin user rm --uid='testuser'"
+    ignore_errors: yes

--- a/benchmark/rgw_benchmark_run.yml
+++ b/benchmark/rgw_benchmark_run.yml
@@ -1,0 +1,16 @@
+---
+- hosts: benchmark_hosts
+  become: True
+  gather_facts: True
+  tasks:
+    - name: Run hummingbird bench  and record version/config info
+      shell: 'echo -e "\nHumminbird Version: `/opt/ceph_bench/hummingbird version`\n\nBench Config Used:\n`cat /opt/ceph_bench/{{ item.name }}`\n\nHummingbird Benchmark Output:\n`/opt/ceph_bench/hummingbird bench /opt/ceph_bench/{{ item.name }}`" | tee /opt/ceph_bench/logs/{{ item.name }}.{{ ansible_date_time.iso8601_basic_short }}.log'
+      register: hummingbird_bench_output
+      with_items:
+        - name: "rgw_bench_test.conf"
+          run_type: (rgw_bench | default(True))
+      when: item.run_type
+    - name: Debug hummingbird-bench outputs
+      debug:
+        var: item.stdout_lines
+      with_items: "{{ hummingbird_bench_output.results }}"

--- a/benchmark/rgw_benchmark_setup.yml
+++ b/benchmark/rgw_benchmark_setup.yml
@@ -4,11 +4,11 @@
   gather_facts: True
   become: True
   tasks:
-    - name: Create user testuser 
-      command: "radosgw-admin user create --uid='testuser' --display-name='Testy Tester'"
+    - name: Create user rgwbench
+      command: "radosgw-admin user create --uid='rgwbench' --display-name='Rgw Benchmark'"
       run_once: True
-    - name: Create subuser testuser:swift 
-      command: "radosgw-admin subuser create --uid='testuser' --subuser='testuser:swift' --access=full --secret='swiftsecret'"
+    - name: Create subuser rgwbench:test
+      command: "radosgw-admin subuser create --uid='rgwbench' --subuser='rgwbench:test' --access=full --secret='{{ bench_rgw_user_password }}'"
       run_once: True
 
 - hosts: benchmark_hosts
@@ -16,8 +16,11 @@
   become: True
   post_tasks:
     ### Using the bench command of Hummingbird for benchmarking it's a single binary with no dependencies or additional libraries.
-    - name: Install benchmark software 
-      shell: 'wget https://github.com/troubling/hummingbird/releases/download/v1.0.0/hummingbird && chmod +x hummingbird && mv hummingbird /opt/ceph_bench/'
+    - name: Install the benchmark software
+      get_url:
+        url: "{{ bench_rgw_hummingbird_url }}"
+        dest: /opt/ceph_bench/
+        mode: 0751
     - name: Template out humminbird bench config file
       config_template:
         src: "templates/{{ item.name }}.j2"

--- a/benchmark/rgw_benchmark_setup.yml
+++ b/benchmark/rgw_benchmark_setup.yml
@@ -1,0 +1,29 @@
+---
+- hosts:
+    - mons
+  gather_facts: True
+  become: True
+  tasks:
+    - name: Create user testuser 
+      command: "radosgw-admin user create --uid='testuser' --display-name='Testy Tester'"
+      run_once: True
+    - name: Create subuser testuser:swift 
+      command: "radosgw-admin subuser create --uid='testuser' --subuser='testuser:swift' --access=full --secret='swiftsecret'"
+      run_once: True
+
+- hosts: benchmark_hosts
+  gather_facts: True
+  become: True
+  post_tasks:
+    ### Using the bench command of Hummingbird for benchmarking it's a single binary with no dependencies or additional libraries.
+    - name: Install benchmark software 
+      shell: 'wget https://github.com/troubling/hummingbird/releases/download/v1.0.0/hummingbird && chmod +x hummingbird && mv hummingbird /opt/ceph_bench/'
+    - name: Template out humminbird bench config file
+      config_template:
+        src: "templates/{{ item.name }}.j2"
+        dest: "/opt/ceph_bench/{{ item.name }}"
+        config_overrides: "{{ item.override }}"
+        config_type: "ini"
+      with_items:
+        - name: "rgw_bench_test.conf"
+          override: "{{ rgw_benchmark_overrides | default({}) }}"

--- a/benchmark/templates/rgw_bench_test.conf.j2
+++ b/benchmark/templates/rgw_bench_test.conf.j2
@@ -1,0 +1,11 @@
+[bench]
+auth=http://{{ internal_lb_vip_address }}:8080/auth/v1.0
+user=testuser:swift
+key=swiftsecret
+concurrency={{ bench_rgw_concurrency | default(15) }} 
+object_size={{ bench_rgw_object_size | default(256)}}
+num_objects={{ bench_rgw_number_of_objects | default(5000) }}
+num_gets={{ bench_rgw_number_of_gets | default(10000)}}
+delete = yes
+auth_version=1.0
+policy_name=gold

--- a/benchmark/templates/rgw_bench_test.conf.j2
+++ b/benchmark/templates/rgw_bench_test.conf.j2
@@ -1,11 +1,11 @@
 [bench]
 auth=http://{{ internal_lb_vip_address }}:8080/auth/v1.0
-user=testuser:swift
-key=swiftsecret
-concurrency={{ bench_rgw_concurrency | default(15) }} 
-object_size={{ bench_rgw_object_size | default(256)}}
-num_objects={{ bench_rgw_number_of_objects | default(5000) }}
-num_gets={{ bench_rgw_number_of_gets | default(10000)}}
+user=rgwbench:test
+key={{ bench_rgw_user_password }}
+concurrency={{ bench_rgw_concurrency | default(50) }} 
+object_size={{ bench_rgw_object_size | default(524288) }}
+num_objects={{ bench_rgw_number_of_objects | default(250000) }}
+num_gets={{ bench_rgw_number_of_gets | default(500000) }}
 delete = yes
 auth_version=1.0
 policy_name=gold

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -21,6 +21,7 @@
 ## Tests
 - include: test-rgw.yml
 - include: ../benchmark/fio_benchmark.yml
+- include: ../benchmark/rgw_benchmark.yml
 
 ## Logging setup and tests
 # This is done after to allow time for the logs

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -103,6 +103,12 @@ fio_test_file_write_overrides:
   fio_test_file:
     size: 10M
 
+### Testing valuses for rgw benchmark
+bench_rgw_concurrency:  15
+bench_rgw_object_size: 256
+bench_rgw_number_of_objects: 5000
+bench_rgw_number_of_gets: 10000
+
 ### Testing specific Ceph vars
 # Set the size of the OSD and journal devices
 # NB if you change the size you will need to change the osd_journal_size

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -104,6 +104,8 @@ fio_test_file_write_overrides:
     size: 10M
 
 ### Testing valuses for rgw benchmark
+bench_rgw_user_password: rgwbenchsecret
+bench_rgw_hummingbird_url:  https://github.com/troubling/hummingbird/releases/download/v1.0.0/hummingbird
 bench_rgw_concurrency:  15
 bench_rgw_object_size: 256
 bench_rgw_number_of_objects: 5000


### PR DESCRIPTION
Setup:
Install the hummingbird binary
Setup the bench.conf configuration file with common defaults
Create a ceph user "testuser" to use for the benchmark
Create a subuser "swift" under "testuser" for the benchmark

Run:
Run the hummingbird benchmark and save the results in a log file

Cleanup:
Remove the bench configuration file and the hummingbird binary
Delete both the subuser and the user created for the benchmark