### PR TITLE
CEPHSTORA-131 Add RPC-O Integration gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,48 @@ export PUBCLOUD_USERNAME=<username>
 export PUBCLOUD_API_KEY=<api_key>
 ```
 
-### Tested builds as AIO
+### AIO Scenarios
 
-* ceph-ansible deployments including RGW.
-* Testing of Ceph components (RGW testing is currently implemented)
-* RPC-MaaS integration
-* RPC-O integration (coming a bit less soon).
+To run an AIO scenario for Ceph you can pick from the following:
+
+**functional**:
+This is a base AIO for Ceph, includes MaaS testing, benchmarking using fio and
+RadosGW benchmarking, this runs on each commit, with the following components:
+
+* 2 x rgw hosts
+* 3 x osd hosts
+* 3 x mon hosts
+* 3 x mgr hosts
+* 1 x rsyslog server
+* HAproxy configured on localhost
+
+**rpco_newton**:
+An RPC-O newton-rc integration test, that will deploy an RPC-O AIO, and
+integrate it with Ceph, followed by Tempest tests. This runs daily, as it takes
+a long time to build.
+
+* RPC-O AIO @ newton-rc
+  * Keystone
+  * Glance
+  * Cinder
+  * Nova
+  * Neutron
+  * Tempest
+* 2 x rgw hosts
+* 3 x osd hosts
+* 3 x mon hosts
+* 3 x mgr hosts
+
+**keystone_rgw**:
+A basic keystone integration test, that will run on each commit.
+Utilizing the swift client to ensure Keystone integration is working.
+
+* Keystone deployed from OpenStack-Ansible role
+* 2 x rgw hosts
+* 3 x osd hosts
+* 3 x mon hosts
+* 3 x mgr hosts
+
 
 ### Currently not supported for AIO
 

--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -21,6 +21,7 @@ env
 echo "+-------------------- START ENV VARS --------------------+"
 
 export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-"functional"}
+export RPC_OPENSTACK_DIR=${RPC_OPENSTACK_DIR:-/opt/rpc-openstack}
 export RPC_MAAS_DIR=${RPC_MAAS_DIR:-/etc/ansible/ceph_roles/rpc-maas}
 export TEST_RPC_MAAS=${TEST_RPC_MAAS:-True}
 
@@ -49,16 +50,88 @@ if which yum; then
     sudo yum -y install redhat-lsb-core epel-release
 fi
 
-if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone_rgw" ]; then
+function _set_rpco_vars {
+  ## Copy over the keystone_auth_admin_password from OSA --> Ceph
+  if ! grep -q keystone_auth_admin_password ${CLONE_DIR}/tests/test-vars-openstack.yml; then
+    grep keystone_auth_admin_password /etc/openstack_deploy/user_osa_secrets.yml >> ${CLONE_DIR}/tests/test-vars-openstack.yml
+  fi
+  ## Add the rsyslog_container into the inventory
+  if ! grep -q rsyslog_container ${CLONE_DIR}/tests/inventory_rpco; then
+    RSYSLOG_HOST=$(lxc-ls -f | grep rsyslog_container | awk {'print $1'})
+    RSYSLOG_HOST_IP=$(grep $RSYSLOG_HOST /etc/hosts | awk {' print $1 '})
+    echo -e "\n[rsyslog_all]\n$RSYSLOG_HOST ansible_host=$RSYSLOG_HOST_IP" >> ${CLONE_DIR}/tests/inventory_rpco
+  fi
+  # Copy over the required vars.
+  cp ${CLONE_DIR}/tests/rpco_vars/user_rpc_ceph_vars.yml /etc/openstack_deploy/user_rpc_ceph_vars.yml
+  CINDER_CEPH_CLIENT_UUID=$(uuidgen)
+  echo "cinder_ceph_client_uuid: $CINDER_CEPH_CLIENT_UUID" >> /etc/openstack_deploy/user_rpc_ceph_vars.yml
+}
+
+function _configure_rpco {
+  if [[ ! -d /opt/rpc-openstack ]]; then
+    git clone https://github.com/rcbops/rpc-openstack -b newton-rc --recursive ${RPC_OPENSTACK_DIR}
+  fi
+  pushd ${RPC_OPENSTACK_DIR}
+    ## Dont use the specified Ceph inventory
+    unset ANSIBLE_INVENTORY
+    ## Set the RPC_ARTIFACT_MODE vars
+    export RPC_APT_ARTIFACT_ENABLED=no
+    export RPC_APT_ARTIFACT_MODE=loose
+    ## Use the openstack-ansible binary
+    export ANSIBLE_BINARY="openstack-ansible"
+    ## Bootstrap RPC-O's ansible
+    bash scripts/bootstrap-ansible.sh
+    ## Bootstrap the AIO vars etc with the scenario in test-vars-openstack.yml
+    export BOOTSTRAP_OPTS="@${CLONE_DIR}/tests/test-vars-openstack.yml"
+    bash scripts/bootstrap-aio.sh
+    ## Build out the hosts, infrastructure and keystone only.
+    pushd ${RPC_OPENSTACK_DIR}/openstack-ansible/playbooks
+      cp ${CLONE_DIR}/tests/rpco_vars/cinder.yml.ceph /etc/openstack_deploy/conf.d/cinder.yml
+      cp inventory/env.d/cinder.yml /etc/openstack_deploy/env.d/cinder.yml
+      sed -i 's/is_metal: true/is_metal: false/g' /etc/openstack_deploy/env.d/cinder.yml
+      sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
+      sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
+      ${ANSIBLE_BINARY} setup-hosts.yml
+      ${ANSIBLE_BINARY} setup-infrastructure.yml
+      ${ANSIBLE_BINARY} os-keystone-install.yml
+    popd
+  popd
+  ## Set the binary and inventory back to ceph's version.
+  export ANSIBLE_BINARY="ceph-ansible-playbook"
+  export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory_rpco -e @tests/test-vars-openstack.yml"
+}
+
+function _deploy_rpco {
+  unset ANSIBLE_INVENTORY
+  export ANSIBLE_BINARY="openstack-ansible"
+  pushd ${RPC_OPENSTACK_DIR}/openstack-ansible/playbooks
+    ${ANSIBLE_BINARY} os-glance-install.yml
+    ${ANSIBLE_BINARY} os-cinder-install.yml
+    ${ANSIBLE_BINARY} os-nova-install.yml
+    ${ANSIBLE_BINARY} os-neutron-install.yml
+    ${ANSIBLE_BINARY} os-tempest-install.yml
+  popd
+}
+
+if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone_rgw" ] || [ "${RE_JOB_SCENARIO}" = "rpco_newton" ]; then
   export CLONE_DIR="$(pwd)"
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
   export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
   export ANSIBLE_BINARY="${ANSIBLE_BINARY:-ceph-ansible-playbook}"
   bash scripts/bootstrap-ansible.sh
-  # Clone the test repos
-  ${ANSIBLE_BINARY} playbooks/git-clone-repos.yml \
-                   -i ${ANSIBLE_INVENTORY} \
-                   -e role_file=../tests/ansible-role-test-requirements.yml
+  # Clone the test repos when not integrating with RPC-O
+  # RPC-O has existing lxc roles that will conflict
+  if [ "${RE_JOB_SCENARIO}" != "rpco_newton" ]; then
+    ${ANSIBLE_BINARY} playbooks/git-clone-repos.yml \
+                     -i ${ANSIBLE_INVENTORY} \
+                     -e role_file=../tests/ansible-role-test-requirements.yml
+  fi
+  ## Clone RPC-O directory into /opt
+  if [ "${RE_JOB_SCENARIO}" == "rpco_newton" ]; then
+    _configure_rpco
+    _set_rpco_vars
+  fi
+  ## Set the inventory and include the additional overrides vars file
   if [ "${RE_JOB_SCENARIO}" = "keystone_rgw" ]; then
     export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory_rgw -e @tests/test-vars-rgw.yml"
   fi
@@ -68,8 +141,11 @@ if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone
   ${ANSIBLE_BINARY} tests/setup-ceph-aio.yml \
                    -i ${ANSIBLE_INVENTORY} \
                    -e @tests/test-vars.yml
+  if [ "${RE_JOB_SCENARIO}" == "rpco_newton" ]; then
+    _deploy_rpco
+  fi
   # Use the rpc-maas deploy to test MaaS
-  if [ "${TEST_RPC_MAAS}" != "False" ] && [ "${RE_JOB_SCENARIO}" != "keystone_rgw" ]; then
+  if [ "${TEST_RPC_MAAS}" != "False" ] && [ "${RE_JOB_SCENARIO}" == "functional" ]; then
     pushd ${RPC_MAAS_DIR}
       export RE_JOB_SCENARIO="ceph"
       bash tests/test-ansible-functional.sh

--- a/tests/inventory_rgw
+++ b/tests/inventory_rgw
@@ -9,6 +9,9 @@ rgw1
 keystone1
 rsyslog1
 
+[lxc_hosts]
+localhost
+
 [hosts]
 localhost
 

--- a/tests/inventory_rpco
+++ b/tests/inventory_rpco
@@ -6,10 +6,6 @@ osd1
 osd2
 allsvc
 rgw1
-rsyslog1
-
-[lxc_hosts]
-localhost
 
 [hosts]
 localhost
@@ -21,7 +17,6 @@ osd1
 osd2
 rgw1
 allsvc
-rsyslog1
 
 [rgws]
 rgw1
@@ -41,12 +36,6 @@ allsvc
 mon1
 mon2
 allsvc
-
-[rsyslog_all]
-rsyslog1
-
-[benchmark_hosts]
-localhost
 
 [haproxy_all]
 localhost

--- a/tests/rpco_vars/cinder.yml.ceph
+++ b/tests/rpco_vars/cinder.yml.ceph
@@ -1,0 +1,22 @@
+---
+storage-infra_hosts:
+  aio1:
+    ip: 172.29.236.100
+
+storage_hosts:
+  aio1:
+    ip: 172.29.236.100
+    container_vars:
+      cinder_backends:
+        limit_container_types: cinder_volume
+        rbd:
+          volume_driver: cinder.volume.drivers.rbd.RBDDriver
+          volume_backend_name: rbd
+          rbd_pool: volumes
+          rbd_ceph_conf: /etc/ceph/ceph.conf
+          rbd_user: cinder
+          rbd_flatten_volume_from_snapshot: false
+          rbd_max_clone_depth: 5
+          rbd_store_chunk_size: 4
+          rados_connect_timeout: -1
+          rbd_secret_uuid: "{{ cinder_ceph_client_uuid }}"

--- a/tests/rpco_vars/user_rpc_ceph_vars.yml
+++ b/tests/rpco_vars/user_rpc_ceph_vars.yml
@@ -1,0 +1,10 @@
+---
+ceph_mons:
+  - 172.29.236.31
+  - 172.29.236.32
+  - 172.29.236.33
+
+ceph_stable_release: luminous
+ceph_pkg_source: ceph
+glance_default_store: rbd
+tempest_run: True

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -1,17 +1,24 @@
 ---
 ## Setup infrastructure on which to deploy Ceph
 - include: setup-containers.yml
+- include: build-containers.yml
 - include: setup-ceph-storage.yml
 
 ## Setup non-ceph components for testing
 - include: ../playbooks/ceph-rsyslog-server.yml
 - include: ../playbooks/ceph-rgw-haproxy.yml
 - include: common/test-install-infra.yml
-  when: radosgw_keystone | bool
+  when:
+    - groups['keystone_all'] is defined
+    - "groups['keystone_all'] | length > 0"
 - include: common/test-install-keystone.yml
-  when: radosgw_keystone | bool
+  when:
+    - groups['keystone_all'] is defined
+    - "groups['keystone_all'] | length > 0"
 - include: test-install-openrc.yml
-  when: radosgw_keystone | bool
+  when:
+    - groups['keystone_all'] is defined
+    - "groups['keystone_all'] | length > 0"
 
 ## Ceph setup
 - include: ../playbooks/deploy-ceph.yml

--- a/tests/setup-containers.yml
+++ b/tests/setup-containers.yml
@@ -1,6 +1,6 @@
 ---
 - name: Playbook for configuring the LXC host
-  hosts: localhost
+  hosts: lxc_hosts
   become: true
   roles:
     - role: "lxc_hosts"
@@ -160,5 +160,3 @@
       command: /usr/local/bin/lxc-system-manage iptables-create
   vars_files:
     - test-vars.yml
-
-- include: build-containers.yml

--- a/tests/test-vars-openstack.yml
+++ b/tests/test-vars-openstack.yml
@@ -1,0 +1,16 @@
+---
+## For OpenStack AIO only build necessary services
+openstack_confd_entries:
+  - name: cinder.yml.aio
+  - name: glance.yml.aio
+  - name: keystone.yml.aio
+  - name: neutron.yml.aio
+  - name: nova.yml.aio
+bootstrap_host_loopback_swift: false
+radosgw_keystone: true
+service_region: RegionOne
+radosgw_keystone_admin_password: testpass
+keystone_admin_user_name: admin
+keystone_admin_tenant_name: admin
+keystone_service_adminuri_insecure: false
+openstack_config: True


### PR DESCRIPTION
Add an rpc-o integration "rpco_newton" scenario.
This builds a base-kit from the newton-rc branch, using only the
following services: Nova, Glance, Keystone, Cinder, Neutron.

In order to build this in a one time go without having to redeploy
certain services for config updates, we deploy in the following order:

* Bootstrap RPC-O ansible
* Bootstrap RPC-O AIO
* Replace env.d/cinder.yml to run is_metal: False
* Deploy RPC-O up until Keystone
* Add configuration options for Ceph
* Deploy Ceph
* Add configuration options for RPC-O
* Deploy Rest of RPC-O (Glance, Cinder, Nova, Neutron)
* Deploy tempest, then test deployment using tempest