### PR TITLE
Bump ceph-ansible to v3.0.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ versions of ``ceph-ansible`` used in RPC deployments.
 
 ## Current versions of ceph-ansible & Ansible
 
-### **ceph-ansible version:** v3.0.25
+### **ceph-ansible version:** v3.0.27
 
 ### **Ansible version:** 2.4.3
 

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,7 +1,7 @@
 - name: ceph-ansible
   scm: git
   src: https://github.com/ceph/ceph-ansible
-  version: v3.0.25
+  version: v3.0.27
 - name: ../ceph_plugins
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-plugins

--- a/scripts/ceph-ansible_increment_release.sh
+++ b/scripts/ceph-ansible_increment_release.sh
@@ -27,7 +27,7 @@ git clone https://github.com/ceph/ceph-ansible /tmp/ceph-ansible_rpc-ceph
 pushd /tmp/ceph-ansible_rpc-ceph
 ## Get the latest tag and save that
 git fetch --tags
-LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+LATEST_TAG=$(git describe --tags `git rev-list --tags` | grep "v3.0" -m 1)
 popd
 ## Cleanup ceph-ansible dir
 rm -rf /tmp/ceph-ansible_rpc-ceph


### PR DESCRIPTION
Additionally, fix ceph-ansible increment release to only focus on v3.0.x
now that the v3.1 beta and rc tags exist.