### PR TITLE
CEPHSTORA-150 Allow group specific overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,15 @@ The inventory should consist of the following:
    * Defaults to remain, but be overriden if required (overrides.yml will take precedence).
    * Git will ignore the overrides.yml file, so the repo can be updated without clearing out all deploy specific vars.
 
-4. Override any variables from ``ceph.conf`` using ``ceph_conf_overrides_extra``:
+4. Override any variables from ``ceph.conf`` using ``ceph_conf_overrides_extra`` or ``ceph_conf_overrides_<group>_extra``:
 
    * This allows the default ``group_vars`` to remain in place, and means you do not have to respecify any vars you aren't setting.
+   * The ``ceph_conf_overrides_<group>_extra`` var will override only vars for only the hosts in that group, with currently supported groups:
+     * ceph_conf_overrides_rgw_extra
+     * ceph_conf_overrides_mon_extra
+     * ceph_conf_overrides_mgr_extra
+     * ceph_conf_overrides_osd_extra
+   * The overrides will merge with the existing settings and take precedence but not squash them.
 
 5. Run the ``bootstrap-ansible.sh`` inside the scripts directory:
 

--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -42,7 +42,7 @@ ceph_conf_overrides_extra: {}
 # overall ceph_conf_overrides_all (above).
 # Additionally, we can set extras as a variable override without having to
 # respecify all the above settings.
-ceph_conf_overrides: "{{ ceph_conf_overrides_all | combine((ceph_conf_overrides_rgw | default({})), ceph_conf_overrides_extra, recursive = True) }}"
+ceph_conf_overrides: "{{ ceph_conf_overrides_all | combine((ceph_conf_overrides_mgr | default({})), (ceph_conf_overrides_rgw | default({})), (ceph_conf_overrides_mon | default({})), (ceph_conf_overrides_osd | default({})), ceph_conf_overrides_extra, recursive = True) }}"
 
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }

--- a/playbooks/group_vars/mgrs/00-defaults.yml
+++ b/playbooks/group_vars/mgrs/00-defaults.yml
@@ -2,4 +2,5 @@
 ## This is a defaults file, it's likely to be changed during repo updates
 ## To override, or update settings, or configuration, create a new file
 ## in this directory, e.g. "overrides.yml" which will take precedence.
-dummy:
+ceph_conf_overrides_mgr_extra: {}
+ceph_conf_overrides_mgr: "{{ ceph_conf_overrides_mgr_extra }}"

--- a/playbooks/group_vars/mons/00-defaults.yml
+++ b/playbooks/group_vars/mons/00-defaults.yml
@@ -2,4 +2,5 @@
 ## This is a defaults file, it's likely to be changed during repo updates
 ## To override, or update settings, or configuration, create a new file
 ## in this directory, e.g. "overrides.yml" which will take precedence.
-dummy:
+ceph_conf_overrides_mon_extra: {}
+ceph_conf_overrides_mon: "{{ ceph_conf_overrides_mon_extra }}"

--- a/playbooks/group_vars/osds/00-defaults.yml
+++ b/playbooks/group_vars/osds/00-defaults.yml
@@ -2,4 +2,5 @@
 ## This is a defaults file, it's likely to be changed during repo updates
 ## To override, or update settings, or configuration, create a new file
 ## in this directory, e.g. "overrides.yml" which will take precedence.
-dummy:
+ceph_conf_overrides_osd_extra: {}
+ceph_conf_overrides_osd: "{{ ceph_conf_overrides_osd_extra }}"

--- a/playbooks/group_vars/rgws/00-defaults.yml
+++ b/playbooks/group_vars/rgws/00-defaults.yml
@@ -16,7 +16,10 @@ radosgw_keystone_service_description: "Ceph RADOS Gateway Service"
 radosgw_keystone_service_region: "{{ service_region }}"
 radosgw_keystone_admin_user: radosgw
 radosgw_keystone_admin_tenant: service
-ceph_conf_overrides_rgw: "{{ (radosgw_keystone | bool) | ternary(ceph_conf_overrides_rgw_keystone, {}) }}"
+## Use this to override existing RGW specific config template settings,
+## whilst keeping the defaults.
+ceph_conf_overrides_rgw_extra: {}
+ceph_conf_overrides_rgw: "{{ (radosgw_keystone | bool) | ternary(ceph_conf_overrides_rgw_keystone, {}) | combine(ceph_conf_overrides_rgw_extra, recursive = True) }}"
 ceph_conf_overrides_rgw_keystone:
   "client.rgw.{{ hostvars[inventory_hostname]['ansible_hostname'] }}":
     # OpenStack integration with Keystone


### PR DESCRIPTION
In some cases you want group specific overrides to apply to a host, for
example you may want to override some RGW settings to only RGW hosts.
However, you may want to keep the defaults. This is specifically
important when adjusting the RGW settings for OpenStack integration.

In order to do this we add an additional setting for each group:
ceph_conf_overrides_rgw_extra
ceph_conf_overrides_mon_extra
ceph_conf_overrides_mgr_extra
ceph_conf_overrides_osd_extra

These will apply to only the hosts in that group, and will take
precedence but not squash existing settings.

Only ceph_conf_overrides_extra will take precedence over these settings
per group,and will be applied to all hosts.