### PR TITLE
CEPHSTORA-151 Adjust run script to work with perf2-15

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -61,8 +61,7 @@ function _set_rpco_vars {
     RSYSLOG_HOST_IP=$(grep $RSYSLOG_HOST /etc/hosts | awk {' print $1 '})
     echo -e "\n[rsyslog_all]\n$RSYSLOG_HOST ansible_host=$RSYSLOG_HOST_IP" >> ${CLONE_DIR}/tests/inventory_rpco
   fi
-  # Copy over the required vars.
-  cp ${CLONE_DIR}/tests/rpco_vars/user_rpc_ceph_vars.yml /etc/openstack_deploy/user_rpc_ceph_vars.yml
+  # Generate Cinder Ceph Client UUID
   CINDER_CEPH_CLIENT_UUID=$(uuidgen)
   echo "cinder_ceph_client_uuid: $CINDER_CEPH_CLIENT_UUID" >> /etc/openstack_deploy/user_rpc_ceph_vars.yml
 }
@@ -81,8 +80,7 @@ function _configure_rpco {
     export ANSIBLE_BINARY="openstack-ansible"
     ## Bootstrap RPC-O's ansible
     bash scripts/bootstrap-ansible.sh
-    ## Bootstrap the AIO vars etc with the scenario in test-vars-openstack.yml
-    export BOOTSTRAP_OPTS="@${CLONE_DIR}/tests/test-vars-openstack.yml"
+    cp ${CLONE_DIR}/tests/rpco_vars/user_rpc_ceph_vars.yml /etc/openstack_deploy/user_rpc_ceph_vars.yml
     bash scripts/bootstrap-aio.sh
     ## Build out the hosts, infrastructure and keystone only.
     pushd ${RPC_OPENSTACK_DIR}/openstack-ansible/playbooks

--- a/tests/rpco_vars/user_rpc_ceph_vars.yml
+++ b/tests/rpco_vars/user_rpc_ceph_vars.yml
@@ -1,4 +1,13 @@
 ---
+# Ensure only the required services are built
+openstack_confd_entries:
+  - name: cinder.yml.aio
+  - name: glance.yml.aio
+  - name: keystone.yml.aio
+  - name: neutron.yml.aio
+  - name: nova.yml.aio
+bootstrap_host_loopback_swift: false
+
 ceph_mons:
   - 172.29.236.31
   - 172.29.236.32

--- a/tests/test-vars-openstack.yml
+++ b/tests/test-vars-openstack.yml
@@ -1,12 +1,4 @@
 ---
-## For OpenStack AIO only build necessary services
-openstack_confd_entries:
-  - name: cinder.yml.aio
-  - name: glance.yml.aio
-  - name: keystone.yml.aio
-  - name: neutron.yml.aio
-  - name: nova.yml.aio
-bootstrap_host_loopback_swift: false
 radosgw_keystone: true
 service_region: RegionOne
 radosgw_keystone_admin_password: testpass


### PR DESCRIPTION
The RPC-O AIO runs on perf2-15 because the general1-8 does not suffice.
We should adjust the RPC-Ceph gate to be able to do the same, so that
the integrated AIO can work more reliably.

In order for this to happen we need to adjust how we pass the values for
the BOOTSTRAP_OPTS and just use the vars we already had specified.