### PR TITLE
CEPHSTORA-152 Enable Swift Tempest tests

### DIFF
--- a/tests/rpco_vars/user_rpc_ceph_vars.yml
+++ b/tests/rpco_vars/user_rpc_ceph_vars.yml
@@ -8,3 +8,4 @@ ceph_stable_release: luminous
 ceph_pkg_source: ceph
 glance_default_store: rbd
 tempest_run: True
+tempest_service_available_swift: True

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -24,6 +24,8 @@
 - include: ../playbooks/deploy-ceph.yml
 - include: ../playbooks/ceph-keystone-rgw.yml
   when: radosgw_keystone | bool
+- include: setup-swiftoperator-user.yml
+  when: radosgw_keystone | bool
 
 ## Tests
 - include: test-rgw.yml

--- a/tests/setup-swiftoperator-user.yml
+++ b/tests/setup-swiftoperator-user.yml
@@ -1,0 +1,29 @@
+---
+## This is needed for the OpenStack Object Storage tempest tests to pass
+- name: Add swiftoperator role to keystone
+  hosts: rgws[0]
+  become: true
+  pre_tasks:
+    - name: Install python-keystoneclient
+      pip:
+        name: python-keystoneclient
+        state: "{{ ((upgrade_ceph_packages | default(False)) | bool) | ternary('latest', 'present') }}"
+      delegate_to: 127.0.0.1
+      register: install_pkgs
+      until: install_pkgs|success
+      retries: 5
+      delay: 2
+    - name: Ensure swiftoperator role
+      keystone:
+        command: "ensure_role"
+        endpoint: "{{ keystone_service_adminurl }}/v3"
+        login_user: "{{ keystone_admin_user_name }}"
+        login_password: "{{ keystone_auth_admin_password }}"
+        login_project_name: "{{ keystone_admin_tenant_name }}"
+        role_name: "swiftoperator"
+        insecure: "{{ keystone_service_adminuri_insecure }}"
+      delegate_to: 127.0.0.1        
+      register: add_service
+      until: add_service|success
+      retries: 5
+      delay: 10

--- a/tests/test-vars-openstack.yml
+++ b/tests/test-vars-openstack.yml
@@ -14,3 +14,7 @@ keystone_admin_user_name: admin
 keystone_admin_tenant_name: admin
 keystone_service_adminuri_insecure: false
 openstack_config: True
+# Ensure RGW hosts have swiftoperator as an accepted role for Tempest
+ceph_conf_overrides_rgw_extra:
+  "client.rgw.{{ hostvars[inventory_hostname]['ansible_hostname'] }}":
+    rgw_keystone_accepted_roles: 'Member, _member_, admin, swiftoperator'


### PR DESCRIPTION
This requires #150 to merge first, and enables teh swiftoperator user
within Keystone, as well as runs the Swift Tempest tests to ensure Ceph
RGW is working properly.