### PR TITLE
Remove defaulted rgw_bench password

### DIFF
--- a/phobos/cap-vars.yml
+++ b/phobos/cap-vars.yml
@@ -15,6 +15,8 @@ fiobench_pgnum: 2048
 fiobench_size: 100G
 ssd_bench: false
 
+bench_rgw_user_password: rgwbenchsecret
+
 monitor_interface: bond0
 public_network: 172.20.40.0/22
 cluster_network: 172.20.40.0/22

--- a/phobos/perf-vars.yml
+++ b/phobos/perf-vars.yml
@@ -15,6 +15,8 @@ ceph_conf_overrides_extra:
   global:
     mon_allow_pool_delete: true
 
+bench_rgw_user_password: rgwbenchsecret
+
 monitor_interface: bond0
 public_network: 172.20.40.0/22
 cluster_network: 172.20.40.0/22

--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -67,7 +67,7 @@ containerized_deployment: false
 cephx: true
 
 # rgw_bench defaults
-bench_rgw_user_password: rgwbenchsecret
+bench_rgw_user_password:
 bench_rgw_hummingbird_url:  https://github.com/troubling/hummingbird/releases/download/v1.0.0/hummingbird
 
 ### Set this password in user_vars


### PR DESCRIPTION
To ensure no defaulted passwords exist we should remove the default
password and only set this for testing.