### PR TITLE
CEPHSTORA-155 Let regular AIO run in perf2-15

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -24,6 +24,8 @@ export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-"functional"}
 export RPC_OPENSTACK_DIR=${RPC_OPENSTACK_DIR:-/opt/rpc-openstack}
 export RPC_MAAS_DIR=${RPC_MAAS_DIR:-/etc/ansible/ceph_roles/rpc-maas}
 export TEST_RPC_MAAS=${TEST_RPC_MAAS:-True}
+export BOOTSTRAP_OPTS=${BOOTSTRAP_OPTS:-""}
+export DATA_DISK_MIN_SIZE_GB=${DATA_DISK_MIN_SIZE_GB:-50}
 
 # Install python2 for Ubuntu 16.04 and CentOS 7
 if which apt-get; then
@@ -111,6 +113,19 @@ function _deploy_rpco {
   popd
 }
 
+function _get_data_disk {
+  # Get minimum disk size
+  DATA_DISK_MIN_SIZE="$((1024**3 * ${DATA_DISK_MIN_SIZE_GB} ))"
+
+  # Determine the largest secondary disk device that meets the minimum size
+  DATA_DISK_DEVICE=$(lsblk -brndo NAME,TYPE,RO,SIZE | awk '/d[b-z]+ disk 0/{ if ($4>m && $4>='$DATA_DISK_MIN_SIZE'){m=$4; d=$1}}; END{print d}')
+
+  # Only set the secondary disk device option if there is one
+  if [ -n "${DATA_DISK_DEVICE}" ]; then
+    export BOOTSTRAP_OPTS="-e bootstrap_host_data_disk_device=${DATA_DISK_DEVICE}"
+  fi
+}
+
 if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone_rgw" ] || [ "${RE_JOB_SCENARIO}" = "rpco_newton" ]; then
   export CLONE_DIR="$(pwd)"
   export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
@@ -136,9 +151,10 @@ if [ "${RE_JOB_SCENARIO}" = "functional" ] || [ "${RE_JOB_SCENARIO}" = "keystone
   if [[ ! -d tests/common ]]; then
     git clone https://github.com/openstack/openstack-ansible-tests -b stable/pike tests/common
   fi
+  _get_data_disk
   ${ANSIBLE_BINARY} tests/setup-ceph-aio.yml \
                    -i ${ANSIBLE_INVENTORY} \
-                   -e @tests/test-vars.yml
+                   -e @tests/test-vars.yml ${BOOTSTRAP_OPTS}
   if [ "${RE_JOB_SCENARIO}" == "rpco_newton" ]; then
     _deploy_rpco
   fi

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -1,5 +1,7 @@
 ---
 ## Setup infrastructure on which to deploy Ceph
+- include: setup-data-disk.yml
+  when: bootstrap_host_data_disk_device is defined
 - include: setup-containers.yml
 - include: build-containers.yml
 - include: setup-ceph-storage.yml

--- a/tests/setup-data-disk.yml
+++ b/tests/setup-data-disk.yml
@@ -1,0 +1,77 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Only execute the disk partitioning process if a partition labeled
+#  'openstack-data{1,2}' is not present and that partition is not
+#  formatted as ext4. This is an attempt to achieve idempotency just
+#  in case these tasks are executed multiple times.
+- name: Setup some localhost bits for MaaS testing
+  hosts: localhost
+  become: true
+  tasks:
+  - name: Determine whether partitions labeled openstack-data{1,2} are present
+    shell: |
+      parted --script -l -m | egrep -q ':ext4:openstack-data[12]:;$'
+    register: data_disk_partitions
+    changed_when: false
+    failed_when: false
+    tags:
+      - check-data-disk-partitions
+
+  - name: Dismount and remove fstab entries for anything on the data disk device
+    mount:
+      name: "{{ item.mount }}"
+      src: "{{ item.device }}"
+      fstype: ext4
+      state: absent
+    when:
+      - data_disk_partitions.rc == 1 or bootstrap_host_data_disk_device_force | bool
+      - item.device | search(bootstrap_host_data_disk_device)
+    with_items:
+      - "{{ ansible_mounts }}"
+
+  - name: Partition the whole data disk for our usage
+    command: "{{ item }}"
+    when: data_disk_partitions.rc == 1 or bootstrap_host_data_disk_device_force | bool
+    with_items:
+      - "parted --script /dev/{{ bootstrap_host_data_disk_device | regex_replace('!','/') }} mklabel gpt"
+      - "parted --align optimal --script /dev/{{ bootstrap_host_data_disk_device | regex_replace('!','/') }} mkpart openstack-data1 ext4 0% 40%"
+      - "parted --align optimal --script /dev/{{ bootstrap_host_data_disk_device | regex_replace('!','/') }} mkpart openstack-data2 ext4 40% 100%"
+    tags:
+      - create-data-disk-partitions
+
+  - name: Format the partitions
+    filesystem:
+      fstype: ext4
+      dev: "{{ item }}"
+    when: data_disk_partitions.rc == 1 or bootstrap_host_data_disk_device_force | bool
+    with_items:
+      - "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}1"
+      - "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}2"
+    tags:
+      - format-data-partitions
+
+  - name: Create the mount points, fstab entries and mount the file systems
+    mount:
+      name: "{{ item.mount_point }}"
+      src: "{{ item.device }}"
+      fstype: ext4
+      state: mounted
+    with_items:
+      - { mount_point: /openstack, device: "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}1"}
+      - { mount_point: /var/lib/lxc, device: "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}2"}
+    tags:
+      - mount-data-partitions


### PR DESCRIPTION
In #118 we fixed the integrated build to work against perf2-15 flavor,
to match what is used by the RPC-O gate.

This fixes the regular rpc-ceph AIO to work on perf2-15, by copying the
approach taken by OSA. This will allow us to adopt the perf2-15 if we
run into performance/memory issues in the future.