### PR TITLE
CEPHSTORA-157 Set default rbd bench to 4k block size

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -25,11 +25,17 @@ defaults to 2G. This will be created in the specified pool, or the default
 The ``fio_bench_list_default`` var, defined in ``benchmark_hosts`` group_vars,
 is the list of default benchmarks. There are 5 main test scenarios:
 
-fio_direct_read_test - Direct reads from an rbd device (libaio or rbd)
-fio_direct_write_test - Direct writes to an rbd device (libaio or rbd)
-fio_rw_mix - Mixture of direct reads and writes to/from an rbd device (libaio or rbd)
-fio_test_file_read - Reads from a mounted rbd device with an xfs file system.
-fio_test_file_write - Writes to a mounted rbd device with an xfs file system.
+ebs_direct_bench - Sequential read, write and rw mix tests using 1M blocks against an nbd-rbd blockdev
+ebs_file_bench   - Random read and write tests using 16k blocks against a mounted nbd-rbd blockdev
+osa_file_bench   - Random read and write tests using 4k blocks against a mounted nbd-rbd blockdev
+ebs_rbd_bench    - Direct random read and write tests using 16k blocks and ioengine=rbd (DEFAULT)
+osa_rbd_bench    - Direct random read and write tests using 4k blocks and ioengine=rbd
+
+By default only the ebs_rbd_bench will run.  To run another test simply set it to true.
+
+Example:
+
+`osa_rbd_bench: true`
 
 Additional tests, with different blocksizes, numjobs and iodepth can be added
 using the ``fio_bench_list_extras`` var, and specifying a different vars for the
@@ -56,30 +62,6 @@ will be in ``/opt/ceph_bench/logs/my_custom_direct_read_test.date_time.log``.
 Additionally, settings can be overridden using config_template overrides. The
 specific overrides var for each benchmark in ``fio_bench_list`` is specified by
 the ``override`` var for each item.
-
-### Running EBS tests
-There are 5 test scenarios based on the document linked above. These are
-meant to represent tests for SSDs and SATA devices. By default all 5 tests will
-run in serial, and output logs to /opt/ceph_bench/<test>.<timestamp>.log.
-This means multiple test runs will generate multiple logs. Additionally, the log
-will store an output of "fio --version" as well as the config used in the test.
-If you would like to run only the sata tests set "ssd_bench=False", or for only
-ssd tests set "sata_bench=False".
-
-SATA tests:
-fio_rw_mix
-fio_direct_read_test
-fio_direct_write_test
-
-SSD Tests:
-fio_test_file_read
-fio_test_file_write
-
-Alternatively, you could adjust the ``fio_bench_list`` vars to set the
-``run_bench`` var to be on/off, or have a different criteria as needed.
-
-For librbd based tests set ssd_bench=false and sata_bench=false and rbd_bench=true
-to run the SATA tests with ioengine=rbd instead of libaio.
 
 ### Benchmark log output
 The output of all FIO runs are stored in ``/opt/ceph_bench/logs``, with the name

--- a/benchmark/fio_benchmark_cleanup.yml
+++ b/benchmark/fio_benchmark_cleanup.yml
@@ -56,10 +56,10 @@
         - "bench_direct_RBD-{{ inventory_hostname_short }}"
       when: keyring.stat.exists
       register: rbd_rm_result
-      failed_when: rbd_rm_result.rc != 2 and rbd_rm_result.rc != 0
+      failed_when: rbd_rm_result.rc not in [0,2]
 
 # Cleanup the benchmark pool if we created it
-- hosts: mons[0]
+- hosts: mons
   become: True
   vars:
     _pool_name: "{{ fiobench_pool_name | default('fiobench') }}"
@@ -77,6 +77,7 @@
     - name: Delete fiobench pool
       command: "ceph osd pool delete {{ _pool_name }} {{ _pool_name }} --yes-i-really-really-mean-it"
       when: fiobench_pool_name is not defined
+      run_once: true
     - name: Set the mon_allow_pool_delete to false if it was before
       command: "ceph daemon mon.{{ ansible_hostname }} config set mon_allow_pool_delete false"
       when:
@@ -84,3 +85,4 @@
         - allow_pool_delete.rc == 0
     - name: Remove client.fiobench user
       command: "ceph auth del client.fiobench"
+      run_once: true

--- a/benchmark/fio_benchmark_setup.yml
+++ b/benchmark/fio_benchmark_setup.yml
@@ -26,14 +26,17 @@
     command: ./configure
     args:
       chdir: /opt/fio
+      creates: /usr/local/bin/fio
   - name: Make fio
     command: make
     args:
       chdir: /opt/fio
+      creates: /usr/local/bin/fio
   - name: Install fio
     command: make install
     args:
       chdir: /opt/fio
+      creates: /usr/local/bin/fio
 
 - name: Create Pool
   hosts:
@@ -100,7 +103,7 @@
         - "bench_direct_RBD-{{ inventory_hostname_short }}"
         - "bench_file-{{ inventory_hostname_short }}"
       register: create_result
-      failed_when: create_result.rc != 17 and create_result.rc != 0
+      failed_when: create_result.rc not in [0,17]
       changed_when: create_result.rc == 0
     - name: Get mapped rbd-nbd devices
       command: "rbd-nbd {{ _ceph_args }} list-mapped"

--- a/phobos/cap-vars.yml
+++ b/phobos/cap-vars.yml
@@ -13,7 +13,6 @@ networks:
 
 fiobench_pgnum: 2048
 fiobench_size: 100G
-ssd_bench: false
 
 bench_rgw_user_password: rgwbenchsecret
 
@@ -40,4 +39,3 @@ dedicated_devices:
   - /dev/sdc
   - /dev/sdc
   - /dev/sdc
-

--- a/phobos/perf-vars.yml
+++ b/phobos/perf-vars.yml
@@ -13,8 +13,6 @@ networks:
 
 fiobench_pgnum: 4096
 fiobench_size: 100G
-sata_bench: false
-ssd_bench: false
 
 bench_rgw_user_password: rgwbenchsecret
 
@@ -47,14 +45,3 @@ devices:
   - /dev/sdw
   - /dev/sdx
   - /dev/sdy
-
-external_lb_vip_address: "{{ bootstrap_host_public_address | default(ansible_default_ipv4.address) }}"
-internal_lb_vip_address: "{{ bootstrap_host_public_address | default(ansible_default_ipv4.address) }}"
-haproxy_default_services:
-  - service:
-    haproxy_service_name: ceph_rgw
-    haproxy_backend_nodes: "{{ groups['rgws'] | default([]) }}"
-    haproxy_port: 8080
-    haproxy_balance_type: "http"
-    haproxy_backend_options:
-      - "httpchk HEAD /"

--- a/playbooks/group_vars/benchmark_hosts/00-defaults.yml
+++ b/playbooks/group_vars/benchmark_hosts/00-defaults.yml
@@ -13,7 +13,7 @@ fio_bench_list_default:
     iodepth: 8
     rw: write
     numjobs: 1
-    run_bench: "{{ sata_bench | default(True) }}"
+    run_bench: "{{ ebs_direct_bench | default(false) }}"
   - src: "fio_direct_test.cfg.j2"
     name: "fio_direct_read_test_EBS"
     override: "{{ fio_direct_read_test_1024k_overrides | default({}) }}"
@@ -21,69 +21,108 @@ fio_bench_list_default:
     iodepth: 8
     rw: read
     numjobs: 1
-    run_bench: "{{ sata_bench | default(True) }}"
+    run_bench: "{{ ebs_direct_bench | default(false) }}"
   - src: "fio_rw_mix.cfg.j2"
-    name: "fio_rw_mix_EBS"
-    override: "{{ fio_rw_mix_1024k_overrides | default({}) }}"
+    name: "fio_direct_rw_mix_EBS"
+    override: "{{ fio_direct_rw_mix_1024k_overrides | default({}) }}"
     blocksize: "1024k"
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ sata_bench | default(True) }}"
+    run_bench: "{{ ebs_direct_bench | default(false) }}"
   - src: "fio_test_file.cfg.j2"
-    name: "fio_test_file_write_EBS"
+    name: "fio_file_randwrite_16k_test_EBS"
     override: "{{ fio_test_file_write_16k_overrides | default({}) }}"
     blocksize: "16k"
     iodepth: 1
     rw: randwrite
     numjobs: 16
-    run_bench: "{{ ssd_bench | default(True) }}"
+    run_bench: "{{ ebs_file_bench | default(false) }}"
   - src: "fio_test_file.cfg.j2"
-    name: "fio_test_file_read_EBS"
+    name: "fio_file_randread_16k_test_EBS"
     override: "{{ fio_test_file_read_16k_overrides | default({}) }}"
     blocksize: "16k"
     iodepth: 1
     rw: randread
     numjobs: 16
-    run_bench: "{{ ssd_bench | default(True) }}"
+    run_bench: "{{ ebs_file_bench | default(false) }}"
   - src: "fio_test_file.cfg.j2"
-    name: "fio_test_file_write_4k_iodepth8"
+    name: "fio_file_randwrite_4k_test_OSA"
     override: "{{ fio_test_file_write_4k_overrides | default({}) }}"
     blocksize: "4k"
+    rw: randwrite
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ ssd_bench | default(True) }}"
+    run_bench: "{{ osa_file_bench | default(false) }}"
   - src: "fio_test_file.cfg.j2"
-    name: "fio_test_file_read_4k_iodepth8"
+    name: "fio_file_randread_test_OSA"
     override: "{{ fio_test_file_read_4k_overrides | default({}) }}"
     blocksize: "4k"
+    rw: randread
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ ssd_bench | default(True) }}"
+    run_bench: "{{ osa_file_bench | default(false) }}"
   - src: "fio_direct_test.cfg.j2"
-    name: "fio_direct_write_test_RBD"
+    name: "fio_rbd_1M_write_test_EBS"
     override: "{{ fio_rbd_write_test_1024k_overrides | default({}) }}"
     blocksize: "1024k"
     ioengine: rbd
+    rw: write
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ rbd_bench | default(True) }}"
+    run_bench: "{{ ebs_rbd_bench | default(true) }}"
   - src: "fio_direct_test.cfg.j2"
-    name: "fio_direct_read_test_RBD"
+    name: "fio_rbd_1M_read_test_EBS"
     override: "{{ fio_rbd_read_test_1024k_overrides | default({}) }}"
     blocksize: "1024k"
     ioengine: rbd
     rw: read
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ rbd_bench | default(True) }}"
+    run_bench: "{{ ebs_rbd_bench | default(true) }}"
   - src: "fio_rw_mix.cfg.j2"
-    name: "fio_rw_mix_RBD"
+    name: "fio_rbd_1M_rw_mix_EBS"
     override: "{{ fio_rbd_rw_mix_1024k_overrides | default({}) }}"
     blocksize: "1024k"
     ioengine: rbd
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ rbd_bench | default(True) }}"
+    run_bench: "{{ osa_rbd_bench | default(true) }}"
+  - src: "fio_direct_test.cfg.j2"
+    name: "fio_rbd_4k_randwrite_test_OSA"
+    override: "{{ fio_rbd_write_test_4k_overrides | default({}) }}"
+    blocksize: "4k"
+    ioengine: rbd
+    rw: randwrite
+    iodepth: 8
+    numjobs: 1
+    run_bench: "{{ osa_rbd_bench | default(false) }}"
+  - src: "fio_direct_test.cfg.j2"
+    name: "fio_rbd_4k_randread_test_OSA"
+    override: "{{ fio_rbd_read_test_4k_overrides | default({}) }}"
+    blocksize: "4k"
+    ioengine: rbd
+    rw: randread
+    iodepth: 8
+    numjobs: 1
+    run_bench: "{{ osa_rbd_bench | default(false) }}"
+  - src: "fio_direct_test.cfg.j2"
+    name: "fio_rbd_16k_randwrite_test_OSA"
+    override: "{{ fio_rbd_write_test_16k_overrides | default({}) }}"
+    blocksize: "16k"
+    ioengine: rbd
+    rw: randwrite
+    iodepth: 8
+    numjobs: 1
+    run_bench: "{{ ebs_rbd_bench | default(true) }}"
+  - src: "fio_direct_test.cfg.j2"
+    name: "fio_rbd_16k_randread_test_OSA"
+    override: "{{ fio_rbd_read_test_16k_overrides | default({}) }}"
+    blocksize: "16k"
+    ioengine: rbd
+    rw: randread
+    iodepth: 8
+    numjobs: 1
+    run_bench: "{{ ebs_rbd_bench | default(true) }}"
 
 fio_bench_list: "{{ (fio_bench_list_default | union(fio_bench_list_extras)) }}"
 fio_bench_list_extras: []

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -81,6 +81,8 @@ ceph_mgr_systemd_overrides:
     PrivateDevices: False
 
 ## Testing specific fio_bench vars
+ebs_direct_bench: true
+ebs_file_bench: true
 fiobench_pgnum: 5
 fiobench_pgpnum: 5
 fio_direct_read_test_1024k_overrides:
@@ -89,7 +91,7 @@ fio_direct_read_test_1024k_overrides:
 fio_direct_write_test_1024k_overrides:
   global:
     runtime: 10
-fio_rw_mix_1024k_overrides:
+fio_direct_rw_mix_1024k_overrides:
   global:
     runtime: 10
 fio_test_file_read_16k_overrides:
@@ -119,6 +121,18 @@ fio_rbd_read_test_1024k_overrides:
   global:
     runtime: 10
 fio_rbd_rw_mix_1024k_overrides:
+  global:
+    runtime: 10
+fio_rbd_read_test_4k_overrides:
+  global:
+    runtime: 10
+fio_rbd_write_test_4k_overrides:
+  global:
+    runtime: 10
+fio_rbd_read_test_16k_overrides:
+  global:
+    runtime: 10
+fio_rbd_write_test_16k_overrides:
   global:
     runtime: 10
 


### PR DESCRIPTION
Updating the default for rbd direct block benchmarking to use a 4k
block size.