### PR TITLE
CEPHSTORA-158 Only run benchmark tests during Keystone integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ export PUBCLOUD_API_KEY=<api_key>
 To run an AIO scenario for Ceph you can pick from the following:
 
 **functional**:
-This is a base AIO for Ceph, includes MaaS testing, benchmarking using fio and
-RadosGW benchmarking, this runs on each commit, with the following components:
+This is a base AIO for Ceph, includes MaaS testing, this runs on each
+commit, with the following components:
 
 * 2 x rgw hosts
 * 3 x osd hosts
@@ -146,6 +146,8 @@ RadosGW benchmarking, this runs on each commit, with the following components:
 * 3 x mgr hosts
 * 1 x rsyslog server
 * HAproxy configured on localhost
+
+This job does not run the benchmarking playbooks.
 
 **rpco_newton**:
 An RPC-O newton-rc integration test, that will deploy an RPC-O AIO, and
@@ -174,6 +176,8 @@ Utilizing the swift client to ensure Keystone integration is working.
 * 3 x mon hosts
 * 3 x mgr hosts
 
+Additionally this test runs the FIO and RGW benchmarking playbooks to ensure
+they work, but does not run the MaaS playbooks.
 
 ### Currently not supported for AIO
 

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -30,7 +30,9 @@
 ## Tests
 - include: test-rgw.yml
 - include: ../benchmark/fio_benchmark.yml
+  when: (test_run_bench | default(False)) | bool
 - include: ../benchmark/rgw_benchmark.yml
+  when: (test_run_bench | default(False)) | bool
 
 ## Logging setup and tests
 # This is done after to allow time for the logs

--- a/tests/test-vars-rgw.yml
+++ b/tests/test-vars-rgw.yml
@@ -51,3 +51,5 @@ haproxy_default_services:
 ### Keystone required settings
 # This is needed to stop the dev mode tasks in OSA from failing.
 pip_install_developer_constraints: "--constraint /opt/developer-pip-constraints.txt"
+
+test_run_bench: True


### PR DESCRIPTION
To reduce the runtime of the functional test, we can run the
Benchmark tests against the Keystone/RGW integration test only. This
test is already shorter because it does not run the MaaS installation
steps.

In this way we reduce the length of time for the functional and RPC
integration tests and still ensure that benchmarking is tested.