### PR TITLE
Link ansible.cfg into tests/benchmark/playbooks

### DIFF
--- a/benchmark/ansible.cfg
+++ b/benchmark/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg


### PR DESCRIPTION
To run the playbooks from the playbooks directory you would need the
ansible.cfg linked.