### PR TITLE
CEPHSTORA-171 Default bootstrap_host_data_disk_device_force

### DIFF
--- a/tests/setup-data-disk.yml
+++ b/tests/setup-data-disk.yml
@@ -38,14 +38,14 @@
       fstype: ext4
       state: absent
     when:
-      - data_disk_partitions.rc == 1 or bootstrap_host_data_disk_device_force | bool
+      - data_disk_partitions.rc == 1 or ((bootstrap_host_data_disk_device_force | default(false)) | bool)
       - item.device | search(bootstrap_host_data_disk_device)
     with_items:
       - "{{ ansible_mounts }}"
 
   - name: Partition the whole data disk for our usage
     command: "{{ item }}"
-    when: data_disk_partitions.rc == 1 or bootstrap_host_data_disk_device_force | bool
+    when: data_disk_partitions.rc == 1 or ((bootstrap_host_data_disk_device_force | default(false)) | bool)
     with_items:
       - "parted --script /dev/{{ bootstrap_host_data_disk_device | regex_replace('!','/') }} mklabel gpt"
       - "parted --align optimal --script /dev/{{ bootstrap_host_data_disk_device | regex_replace('!','/') }} mkpart openstack-data1 ext4 0% 40%"
@@ -57,7 +57,7 @@
     filesystem:
       fstype: ext4
       dev: "{{ item }}"
-    when: data_disk_partitions.rc == 1 or bootstrap_host_data_disk_device_force | bool
+    when: data_disk_partitions.rc == 1 or ((bootstrap_host_data_disk_device_force | default(false)) | bool)
     with_items:
       - "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}1"
       - "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}2"

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -1,6 +1,7 @@
 ---
 force_containers_destroy: True
 force_containers_data_destroy: False
+bootstrap_host_data_disk_device_force: False
 ansible_addr_prefix: "172.29.236"
 storage_addr_prefix: "172.29.244"
 bridges:


### PR DESCRIPTION
In the integrated build RPC-O has already setup the disk partitions,
this means that it won't run unless
bootstrap_host_data_disk_device_force is set to True, since it isn't set
at all the task fails.

This PR defaults to false, which will work for the RPC-O integration
build and the normal rpc-ceph builds on perf2-15 instances.