### PR TITLE
Add MaaS secrets to ansible run

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -130,7 +130,7 @@ function _get_data_disk {
 
 export CLONE_DIR="$(pwd)"
 export ANSIBLE_INVENTORY="${CLONE_DIR}/tests/inventory"
-export ANSIBLE_OVERRIDES="${CLONE_DIR}/tests/test-vars.yml"
+export ANSIBLE_PARAMETERS="-e @${CLONE_DIR}/tests/test-vars.yml -e @${RPC_MAAS_DIR}/tests/user_rpcm_secrets.yml"
 export ANSIBLE_BINARY="${ANSIBLE_BINARY:-ceph-ansible-playbook}"
 bash scripts/bootstrap-ansible.sh
 # Clone the test repos when not integrating with RPC-O


### PR DESCRIPTION
In https://github.com/rcbops/rpc-maas/pull/449 there is a requirement
for some password vars that are otherwise not set. This will cause our
rpc-ceph job to fail, to get ahead of the game this PR adds the vars
file as an overrides file for the gate jobs that utilise MaaS.