### PR TITLE
[CEPHSTORA-185] Tag pin pip-install role

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,12 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-pyasn1!=0.2.3 # BSD
-pyOpenSSL>=0.14 # Apache-2.0
-# NOTE(mattt): This pulls in urllib3, so we disable to avoid the issue
-#              mentioned below
-#requests>=2.14.2 # Apache-2.0
+pyasn1!=0.2.3,>=0.1.8 # BSD
+pyOpenSSL>=17.1.0 # Apache-2.0
 ndg-httpsclient>=0.4.2;python_version<'3.0' # BSD
-netaddr!=0.7.16,>=0.7.13 # BSD
+netaddr>=0.7.18 # BSD
 PrettyTable<0.8,>=0.7.1 # BSD
-pycrypto>=2.6 # Public Domain
 python-memcached>=1.56 # PSF
-PyYAML>=3.10.0 # MIT
-# NOTE(mattt): This causes issues w/ ansible's apt_key module and SNI
-#urllib3>=1.21.1 # MIT
-virtualenv>=13.1.0 # MIT
+PyYAML>=3.12 # MIT
+virtualenv>=14.0.6 # MIT
 shade>=1.26.0

--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -13,7 +13,7 @@
 - name: pip_install
   src: https://git.openstack.org/openstack/openstack-ansible-pip_install
   scm: git
-  version: stable/pike
+  version: 1dfc0599f28989a614a978bd1c9e842c4687e9e7
 - name: rpc-maas
   src: https://github.com/rcbops/rpc-maas
   scm: git


### PR DESCRIPTION
A bug in the upstream pip_install has caused the pip_install role to
fail for the rpc-ceph gate due to an undefined variable.

To get around this we can tag pin to the latest stable release of
stable/pike and utilise that (16.0.9).