### PR TITLE
CEPHSTORA-185 Fix requirements for PyYAML

### DIFF
--- a/playbooks/ceph-keystone-rgw.yml
+++ b/playbooks/ceph-keystone-rgw.yml
@@ -8,6 +8,7 @@
       pip:
         name: python-keystoneclient
         state: "{{ ((upgrade_ceph_packages | default(False)) | bool) | ternary('latest', 'present') }}"
+        extra_args: "--ignore-installed"
       delegate_to: 127.0.0.1
       run_once: true
       register: install_pkgs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,12 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-pyasn1!=0.2.3 # BSD
-pyOpenSSL>=0.14 # Apache-2.0
-# NOTE(mattt): This pulls in urllib3, so we disable to avoid the issue
-#              mentioned below
-#requests>=2.14.2 # Apache-2.0
+pyasn1!=0.2.3,>=0.1.8 # BSD
+pyOpenSSL>=17.1.0 # Apache-2.0
 ndg-httpsclient>=0.4.2;python_version<'3.0' # BSD
-netaddr!=0.7.16,>=0.7.13 # BSD
+netaddr>=0.7.18 # BSD
 PrettyTable<0.8,>=0.7.1 # BSD
-pycrypto>=2.6 # Public Domain
 python-memcached>=1.56 # PSF
-PyYAML>=3.10.0 # MIT
-# NOTE(mattt): This causes issues w/ ansible's apt_key module and SNI
-#urllib3>=1.21.1 # MIT
-virtualenv>=13.1.0 # MIT
+PyYAML>=3.12 # MIT
+virtualenv>=14.0.6 # MIT
 shade>=1.26.0


### PR DESCRIPTION
python-keystoneclient fails to install because a requirement for PyYAML
3.0.12 is installed. We should use this as a chance to update our
requirements file.