### PR TITLE
Bump ceph-ansible to v3.0.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ versions of ``ceph-ansible`` used in RPC deployments.
 
 ## Current versions of ceph-ansible & Ansible
 
-### **ceph-ansible version:** v3.0.28
+### **ceph-ansible version:** v3.0.29
 
-### **Ansible version:** 2.4.3
+### **Ansible version:** 2.4.4.0
 
 ## What is rpc-ceph?
 

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,7 +1,7 @@
 - name: ceph-ansible
   scm: git
   src: https://github.com/ceph/ceph-ansible
-  version: v3.0.28
+  version: v3.0.29
 - name: ../ceph_plugins
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-plugins

--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -17,12 +17,7 @@ ceph_stable_release: luminous
 # Let's round that up to 20GB as a lazy/safe option
 journal_size: "{{ osd_journal_size | default('20480') }}"
 
-# Set osd filesystem settings
-osd_mkfs_type: xfs
-osd_mkfs_options_xfs: -f -i size=2048
-osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: filestore
-
 
 radosgw_civetweb_num_threads: 8192
 ceph_conf_overrides_all:
@@ -108,7 +103,6 @@ os_tuning_params:
 
 disable_transparent_hugepage: false
 containerized_deployment: false
-cephx: true
 
 # rgw_bench defaults
 bench_rgw_user_password:
@@ -122,6 +116,8 @@ radosgw_keystone: false
 # Set to true if using PKI keys
 radosgw_keystone_ssl: false
 
+# Default this to ceph-ansible default so VIPs can be configured
+radosgw_civetweb_port: 8080
 radosgw_service_publicurl: "https://{{ external_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
 radosgw_service_adminurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
 radosgw_service_internalurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
@@ -133,7 +129,7 @@ haproxy_default_services:
   - service:
       haproxy_service_name: ceph_rgw
       haproxy_backend_nodes: "{{ groups['rgws'] | default([]) }}"
-      haproxy_port: 8080
+      haproxy_port: "{{ radosgw_civetweb_port }}"
       haproxy_balance_type: "http"
       haproxy_backend_options:
         - "httpchk HEAD /"

--- a/playbooks/group_vars/osds/osds.yml.sample
+++ b/playbooks/group_vars/osds/osds.yml.sample
@@ -71,6 +71,7 @@ dummy:
 
 # Declare devices to be used as OSDs
 # All scenario(except 3rd) inherit from the following device declaration
+# Note: This scenario uses the ceph-disk tool to provision OSDs
 
 #devices:
 #  - /dev/sdb
@@ -115,6 +116,7 @@ dummy:
 # /dev/sda1: UUID="9c43e346-dd6e-431f-92d8-cbed4ccb25f6" TYPE="xfs" PARTLABEL="ceph data" PARTUUID="749c71c9-ed8f-4930-82a7-a48a3bcdb1c7"
 # /dev/sda2: PARTLABEL="ceph block" PARTUUID="e6ca3e1d-4702-4569-abfa-e285de328e9d"
 #
+# Note: This scenario uses the ceph-disk tool to provision OSDs
 
 #osd_scenario: "{{ 'collocated' if journal_collocation or dmcrypt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_osd_scenarios:
@@ -175,6 +177,8 @@ dummy:
 # /dev/sdb: PTTYPE="gpt"
 # /dev/sdb1: PARTLABEL="ceph block.db" PARTUUID="af5b2d74-4c08-42cf-be57-7248c739e217"
 # /dev/sdb2: PARTLABEL="ceph block.wal" PARTUUID="af3f8327-9aa9-4c2b-a497-cf0fe96d126a"
+#
+# Note: This scenario uses the ceph-disk tool to provision OSDs
 #dedicated_devices: "{{ raw_journal_devices if raw_multi_journal or dmcrypt_dedicated_journal else [] }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
@@ -194,6 +198,7 @@ dummy:
 # /dev/sdb1: PARTLABEL="ceph block.db" PARTUUID="0734f6b6-cc94-49e9-93de-ba7e1d5b79e3"
 # /dev/sdc: PTTYPE="gpt"
 # /dev/sdc1: PARTLABEL="ceph block.wal" PARTUUID="824b84ba-6777-4272-bbbd-bfe2a25cecf3"
+# Note: This option uses the ceph-disk tool
 #bluestore_wal_devices: "{{ dedicated_devices }}"
 
 # III. Use ceph-volume to create OSDs from logical volumes.

--- a/playbooks/group_vars/rgws/00-defaults.yml
+++ b/playbooks/group_vars/rgws/00-defaults.yml
@@ -4,7 +4,6 @@
 ## in this directory, e.g. "overrides.yml" which will take precedence.
 radosgw_address_block: "{{ public_network }}"
 radosgw_civetweb_bind_ip: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ipaddr(radosgw_address_block) | first }}"
-radosgw_civetweb_port: 8080
 internal_lb_vip_address: "127.0.0.1"
 keystone_service_adminurl: "http://{{ internal_lb_vip_address }}:35357"
 ## RadosGW Integration vars


### PR DESCRIPTION
Additionally, clear up vars that we set that match the default of
ceph-ansible (and are therefore unrequired), unless they are used
by playbooks that don't import the ceph-defaults role.

This bump fixes the spurious restarts due to config_template not
honouring ordering of configuration files. CEPHSTORA-166