### PR TITLE
CEPHSTORA-199 Fix disable_transparent_hugepage

### DIFF
--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -101,7 +101,6 @@ os_tuning_params:
   - { name: vm.swappiness, value: 0 }
   - { name: vm.dirty_background_ratio, value: 3}
 
-disable_transparent_hugepage: false
 containerized_deployment: false
 
 # rgw_bench defaults

--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -103,3 +103,10 @@
     - name: Remount /proc/sys rw
       command: "mount -o remount rw /proc/sys"
       when: ansible_os_family | lower == "redhat"
+
+# For transparent_hugepage disable we need this for the AIO
+- name: Fix /sys perms for OSDs
+  hosts: osds
+  tasks:
+    - name: Remount /proc/sys rw
+      command: "mount -o remount rw /sys"


### PR DESCRIPTION
We should default this to the ceph-ansible default which is "true". This
was set to false when the initial AIO was setup, but should not have
been left in place.

In order for that setting to work we need to configure OSD hosts to
remounte /sys rw for the AIO containers.