### PR TITLE
CEPHSTORA-218 Set no_log: True on tasks involving passwords

### DIFF
--- a/playbooks/ceph-keystone-rgw.yml
+++ b/playbooks/ceph-keystone-rgw.yml
@@ -33,6 +33,7 @@
       until: add_service|success
       retries: 5
       delay: 2
+      no_log: True
       tags:
         - ceph-rgw-setup
         - rgw-service-add
@@ -55,6 +56,7 @@
       until: add_service|success
       retries: 5
       delay: 10
+      no_log: True
       tags:
         - ceph-rgw-setup
         - rgw-service-add
@@ -104,6 +106,7 @@
       until: add_service|success
       retries: 5
       delay: 10
+      no_log: True
       tags:
         - ceph-rgw-setup
         - rgw-service-add


### PR DESCRIPTION
To avoid leaking passwords when configuring keystone endpoints, we
should set no_log: True, this will mean the passwords aren't shown when
we use verbose mode, or callback plugins.