### PR TITLE
CEPHSTORA-222 Use Ansible 2.5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ versions of ``ceph-ansible`` used in RPC deployments.
 
 ### **ceph-ansible version:** v3.0.33
 
-### **Ansible version:** 2.4.4.0
+### **Ansible version:** 2.5.1.0
 
 ## What is rpc-ceph?
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,14 +3,7 @@
 library            = /etc/ansible/ceph_plugins/library:/etc/ansible/ceph_roles/ceph-ansible/library
 # set plugin path directories here, separate with colons
 action_plugins     = /etc/ansible/ceph_plugins/action:/etc/ansible/ceph_roles/ceph-ansible/plugins/actions
-cache_plugins      = /etc/ansible/ceph_plugins/cache
 callback_plugins   = /etc/ansible/ceph_plugins/callback:/etc/ansible/ceph_roles/ceph-ansible/plugins/callback
 connection_plugins = /etc/ansible/ceph_plugins/connection
-lookup_plugins     = /etc/ansible/ceph_plugins/lookup
-inventory_plugins  = /etc/ansible/ceph_plugins/inventory
-vars_plugins       = /etc/ansible/ceph_plguins/vars_plugins
 filter_plugins     = /etc/ansible/ceph_plugins/filter
-test_plugins       = /etc/ansible/ceph_plugins/test
-terminal_plugins   = /etc/ansible/ceph_plugins/terminal
-strategy_plugins   = /etc/ansible/ceph_plugins/strategy
 roles_path         = /etc/ansible/ceph_roles/ceph-ansible/roles:/etc/ansible/ceph_roles:/etc/ansible/roles

--- a/phobos/README.md
+++ b/phobos/README.md
@@ -124,7 +124,7 @@ From the root of the rpc-ceph repo clone:
 * set `client_count` to the number of clients desired.
 
 ```bash
-$ pip install -r requirements.txt ansible==2.4.3.0
+$ pip install -r requirements.txt ansible==2.5.2.0
 $ ansible-playbook -e cluster_deploy_version=perf-v01 \
                    -e ssh_keyname=mykey \
                    -e stor_count=3 \

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -1,6 +1,6 @@
 set -e -u -x
 
-export ANSIBLE_PACKAGE=${ANSIBLE_PACKAGE:-"ansible==2.4.4.0"}
+export ANSIBLE_PACKAGE=${ANSIBLE_PACKAGE:-"ansible==2.5.2.0"}
 export SSH_DIR=${SSH_DIR:-"/root/.ssh"}
 export ANSIBLE_ROLE_FILE=${ANSIBLE_ROLE_FILE:-"ansible-role-requirements.yml"}
 # Set the role fetch mode to any option [git-clone]

--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -2,6 +2,10 @@
   src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
   scm: git
   version: stable/pike
+- name: ../ceph_plugins
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-plugins
+  version: 587eea909c0a27a9f6015b31d14077dcc14943bb
 - name: lxc_container_create
   src: https://git.openstack.org/openstack/openstack-ansible-lxc_container_create
   scm: git


### PR DESCRIPTION
This PR reorganizes how we adopt plugins to facilitate ansible 2.5.1.0
Primarly, we no longer need all the plugins from OSA for Ceph to work,
since the config_template plugin has moved. To address this the PR
moves the osa-plugins repo dependency to the tests role requirements,
and installs a separate config_template role dependency.

This allows us to use ceph-ansible v3.0.x with Ansible 2.5.

Additionally, as part of getting ready for the release of ceph-ansible
v3.1.0 we should adopt the paths for the ceph-ansible library, callback
and actions plugins.