### PR TITLE
CEPHSTORA-234 Add play to install ssacli

### DIFF
--- a/phobos/cap-vars.yml
+++ b/phobos/cap-vars.yml
@@ -14,6 +14,8 @@ networks:
 fiobench_pgnum: 2048
 fiobench_size: 100G
 
+install_ssacli: true
+
 bench_rgw_user_password: rgwbenchsecret
 
 monitor_interface: bond0

--- a/phobos/perf-vars.yml
+++ b/phobos/perf-vars.yml
@@ -14,6 +14,8 @@ networks:
 fiobench_pgnum: 4096
 fiobench_size: 100G
 
+install_ssacli: true
+
 bench_rgw_user_password: rgwbenchsecret
 
 monitor_interface: bond0

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -14,3 +14,7 @@
 - name: Configure RGW HAProxy
   import_playbook: ceph-rgw-haproxy.yml
   when: "{{ rgw_haproxy | default(true) }}"
+
+- name: Install ssacli
+  import_playbook: ssacli-install.yml
+  when: "{{ install_ssacli | default(false) }}"

--- a/playbooks/ssacli-install.yml
+++ b/playbooks/ssacli-install.yml
@@ -1,0 +1,30 @@
+---
+- hosts: osds
+  become: true
+  gather_facts: false
+  tasks:
+
+    - name: Add apt-keys
+      apt_key:
+        url: "http://downloads.linux.hpe.com/SDR/{{ item }}"
+      with_items:
+        - hpPublicKey1024.pub
+        - hpPublicKey2048.pub
+        - hpPublicKey2048_key1.pub
+        - hpePublicKey2048_key1.pub
+
+    - name: Add apt source
+      copy:
+        src: downloads_linux_hpe_com_SDR_repo_mcp.list
+        dest: /etc/apt/sources.list.d/downloads_linux_hpe_com_SDR_repo_mcp.list
+
+    - name: Get ssacli version to install
+      set_fact:
+        ssacli_name: "ssacli={{ ssacli_version }}"
+      when: ssacli_version is defined
+
+    - name: install ssacli
+      apt:
+        name: "{{ ssacli_name | default('ssacli') }}"
+        state: present
+        update_cache: true


### PR DESCRIPTION
Playbook to install ssacli at version default latest or ssacli_version.
By default the play will not be included in a deploy, but can be enabled
with install_ssacli: true