### PR TITLE
CEPHSTORA-175 Fix netmask on osd2

### DIFF
--- a/tests/host_vars/osd2.yml
+++ b/tests/host_vars/osd2.yml
@@ -6,11 +6,11 @@ container_networks:
     address: "{{ ansible_host }}"
     bridge: "br-mgmt"
     interface: "eth1"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"
   storage_address:
     address: "{{ ceph_storage_address }}"
     bridge: "br-storage"
     interface: "eth2"
-    netmask: "255.255.255.0"
+    netmask: "255.255.252.0"
     type: "veth"


### PR DESCRIPTION
The RPC-O integration jobs are failing because the glance/cinder hosts
can connect to the mon hosts but can't connect to the osd2 host. The
netmask was incorrect on the osd2 host only.