### PR TITLE
Increment release should include all changed playbooks

### DIFF
--- a/scripts/ceph-ansible_increment_release.sh
+++ b/scripts/ceph-ansible_increment_release.sh
@@ -37,7 +37,7 @@ wget https://raw.githubusercontent.com/ceph/ceph-ansible/$LATEST_TAG/site.yml.sa
 wget https://raw.githubusercontent.com/ceph/ceph-ansible/$LATEST_TAG/infrastructure-playbooks/rolling_update.yml -O ${PWD}/${PATH_TO_PLAYBOOKS}playbooks/rolling_update.yml
 wget https://raw.githubusercontent.com/ceph/ceph-ansible/$LATEST_TAG/infrastructure-playbooks/osd-configure.yml -O ${PWD}/${PATH_TO_PLAYBOOKS}playbooks/osd-configure.yml
 wget https://raw.githubusercontent.com/ceph/ceph-ansible/$LATEST_TAG/infrastructure-playbooks/purge-cluster.yml -O ${PWD}/${PATH_TO_PLAYBOOKS}playbooks/purge-cluster.yml
-git add ${PATH_TO_PLAYBOOKS}playbooks/deploy-ceph.yml
+git add ${PATH_TO_PLAYBOOKS}playbooks/*.yml
 for vars_file in mons mgrs rgws osds all; do
   wget https://raw.githubusercontent.com/ceph/ceph-ansible/$LATEST_TAG/group_vars/$vars_file.yml.sample -O ${PWD}/${PATH_TO_PLAYBOOKS}playbooks/group_vars/$vars_file/$vars_file.yml.sample
   git add ${PATH_TO_PLAYBOOKS}playbooks/group_vars/$vars_file/$vars_file.yml.sample


### PR DESCRIPTION
Release increment currently only git adds the deploy-ceph.yml playbook
and not the other playbooks we create. This PR fixes that.