### PR TITLE
Fix cidr for ironic network in sample vars file

### DIFF
--- a/phobos/cap-vars.yml
+++ b/phobos/cap-vars.yml
@@ -19,8 +19,8 @@ install_ssacli: true
 bench_rgw_user_password: rgwbenchsecret
 
 monitor_interface: bond0
-public_network: 172.20.41.0/22
-cluster_network: 172.20.41.0/22
+public_network: 172.20.40.0/22
+cluster_network: 172.20.40.0/22
 osd_scenario: non-collocated
 devices:
   - /dev/sdd

--- a/phobos/perf-vars.yml
+++ b/phobos/perf-vars.yml
@@ -19,8 +19,8 @@ install_ssacli: true
 bench_rgw_user_password: rgwbenchsecret
 
 monitor_interface: bond0
-public_network: 172.20.41.0/22
-cluster_network: 172.20.41.0/22
+public_network: 172.20.40.0/22
+cluster_network: 172.20.40.0/22
 osd_scenario: collocated
 devices:
   - /dev/sdb


### PR DESCRIPTION
In a previous change I munged the subnet cidr for the ironic network in
the phobos environment.