### PR TITLE
Add apt-transport-https package for MaaS test

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -184,6 +184,9 @@ fi
 if [ "${TEST_RPC_MAAS}" != "False" ] && [ "${RE_JOB_SCENARIO}" == "functional" ]; then
   pushd ${RPC_MAAS_DIR}
     export RE_JOB_SCENARIO="ceph"
+    ## This is needed for the maas job to be able to update the apt cache
+    ## When the influxdb repo is present.
+    apt-get install -y apt-transport-https
     bash tests/test-ansible-functional.sh
   popd
 fi


### PR DESCRIPTION
The maas jobs are failing with an apt update failure. This should help
debug the issue.