### PR TITLE
CEPHSTORA-176 Add parted package to integrated build jobs

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -81,6 +81,8 @@ function _configure_rpco {
     git clone https://github.com/rcbops/rpc-openstack -b ${RPCO_VERSION} --recursive ${RPCO_DIR}
   fi
   pushd ${RPCO_DIR}
+    # Install parted for the integrated build.
+    apt-get install -y parted
     ## Dont use the specified Ceph inventory
     unset ANSIBLE_INVENTORY
     ## Set the RPC_ARTIFACT_MODE vars


### PR DESCRIPTION
The integrated build jobs for Newton require parted to be installed, the
new gate image does not have parted. This PR installs parted.