### PR TITLE
CEPHSTORA-272 Install required packages

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -81,8 +81,8 @@ function _configure_rpco {
     git clone https://github.com/rcbops/rpc-openstack -b ${RPCO_VERSION} --recursive ${RPCO_DIR}
   fi
   pushd ${RPCO_DIR}
-    # Install parted for the integrated build.
-    apt-get install -y parted
+    # Install required packages for the integrated build.
+    apt-get install -y parted iptables util-linux
     ## Dont use the specified Ceph inventory
     unset ANSIBLE_INVENTORY
     ## Set the RPC_ARTIFACT_MODE vars


### PR DESCRIPTION
The change to use nodepool in Releng has meant some packages are not
available on the base image (iptables/parted/util-linux). We should
install these so the integrated builds can succeed.