### PR TITLE
CEPHSTORA-278 Don't set hostname to match host

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -109,8 +109,6 @@ function _configure_rpco {
       cp ${CLONE_DIR}/tests/rpco_vars/cinder.yml.ceph /etc/openstack_deploy/conf.d/cinder.yml
       cp ${CINDER_ENVD} /etc/openstack_deploy/env.d/cinder.yml
       sed -i 's/is_metal: true/is_metal: false/g' /etc/openstack_deploy/env.d/cinder.yml
-      sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/openstack_user_config.yml
-      sed -i "s/aio1/$(hostname)/" /etc/openstack_deploy/conf.d/*.yml
       ${ANSIBLE_BINARY} setup-hosts.yml
       ${ANSIBLE_BINARY} setup-infrastructure.yml
       ${ANSIBLE_BINARY} os-keystone-install.yml


### PR DESCRIPTION
The gate jobs create instances with really long names resulting in job
failures for OSA containers. This PR removes the setting of the hostname
to match the host itself.