### PR TITLE
CEPHSTORA-280 Test purge-cluster playbook

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -189,4 +189,9 @@ if [ "${TEST_RPC_MAAS}" != "False" ] && [ "${RE_JOB_SCENARIO}" == "functional" ]
     apt-get install -y apt-transport-https
     bash tests/test-ansible-functional.sh
   popd
+  ## Test purge-cluster
+  ${ANSIBLE_BINARY} playbooks/purge-cluster.yml \
+                   -i ${ANSIBLE_INVENTORY} \
+                   -e @tests/test-vars.yml ${CEPH_BOOTSTRAP_OPTS} \
+                   -e ireallymeanit=yes
 fi

--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -108,5 +108,7 @@
 - name: Fix /sys perms for OSDs
   hosts: osds
   tasks:
-    - name: Remount /proc/sys rw
+    - name: Remount /sys rw
       command: "mount -o remount rw /sys"
+    - name: Remount /proc/sys rw
+      command: "mount -o remount rw /proc/sys"


### PR DESCRIPTION
We weren't setting the action plugins path correctly in our last
release, which meant the purge-cluster.yml playbook didn't work. This
has been fixed, but we should test the playbook as part of the build
jobs to ensure this works.