### PR TITLE
CEPHSTORA-277 Add group_vars to benchmark directories

### DIFF
--- a/benchmark/fio_bench/group_vars
+++ b/benchmark/fio_bench/group_vars
@@ -1,0 +1,1 @@
+../../playbooks/group_vars

--- a/benchmark/rgw_bench/group_vars
+++ b/benchmark/rgw_bench/group_vars
@@ -1,0 +1,1 @@
+../../playbooks/group_vars


### PR DESCRIPTION
Since moving fio_bench and rgw_bench plays into their own directories we
should link the group_vars into this directory to ensure the group_vars
are read when calling the individual playbooks.