### PR TITLE
Add uuid-runtime package

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -82,7 +82,7 @@ function _configure_rpco {
   fi
   pushd ${RPCO_DIR}
     # Install required packages for the integrated build.
-    apt-get install -y parted iptables util-linux
+    apt-get install -y parted iptables util-linux uuid-runtime
     ## Dont use the specified Ceph inventory
     unset ANSIBLE_INVENTORY
     ## Set the RPC_ARTIFACT_MODE vars


### PR DESCRIPTION
Gating issue relating to no uuid-runtime package being available in the
base gate image.