### PR TITLE
[WIP] Initial PR to add bionic AIO support

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -2,7 +2,7 @@
   scm: git
   src: https://github.com/ceph/ceph-ansible
   version: v3.0.34
-- name: ../ceph_plugins
+- name: plugins
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
   version: 17.0.0.0b3

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,16 +1,16 @@
 [defaults]
 
-library            = /etc/ansible/ceph_plugins/library:/etc/ansible/ceph_roles/ceph-ansible/library
+library            = /etc/ansible/ceph_roles/plugins/library:/etc/ansible/ceph_roles/ceph-ansible/library
 # set plugin path directories here, separate with colons
-action_plugins     = /etc/ansible/ceph_plugins/action:/etc/ansible/ceph_roles/ceph-ansible/plugins/actions
-cache_plugins      = /etc/ansible/ceph_plugins/cache
-callback_plugins   = /etc/ansible/ceph_plugins/callback:/etc/ansible/ceph_roles/ceph-ansible/plugins/callback
-connection_plugins = /etc/ansible/ceph_plugins/connection
-lookup_plugins     = /etc/ansible/ceph_plugins/lookup
-inventory_plugins  = /etc/ansible/ceph_plugins/inventory
-vars_plugins       = /etc/ansible/ceph_plguins/vars_plugins
-filter_plugins     = /etc/ansible/ceph_plugins/filter
-test_plugins       = /etc/ansible/ceph_plugins/test
-terminal_plugins   = /etc/ansible/ceph_plugins/terminal
-strategy_plugins   = /etc/ansible/ceph_plugins/strategy
+action_plugins     = /etc/ansible/ceph_roles/plugins/action:/etc/ansible/ceph_roles/ceph-ansible/plugins/actions
+cache_plugins      = /etc/ansible/ceph_roles/plugins/cache
+callback_plugins   = /etc/ansible/ceph_roles/plugins/callback:/etc/ansible/ceph_roles/ceph-ansible/plugins/callback
+connection_plugins = /etc/ansible/ceph_roles/plugins/connection
+lookup_plugins     = /etc/ansible/ceph_roles/plugins/lookup
+inventory_plugins  = /etc/ansible/ceph_roles/plugins/inventory
+vars_plugins       = /etc/ansible/ceph_roles/plguins/vars_plugins
+filter_plugins     = /etc/ansible/ceph_roles/plugins/filter
+test_plugins       = /etc/ansible/ceph_roles/plugins/test
+terminal_plugins   = /etc/ansible/ceph_roles/plugins/terminal
+strategy_plugins   = /etc/ansible/ceph_roles/plugins/strategy
 roles_path         = /etc/ansible/ceph_roles/ceph-ansible/roles:/etc/ansible/ceph_roles:/etc/ansible/roles

--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -80,7 +80,7 @@
     lxc_container:
       name: "{{ container_name }}"
       container_config:
-        - "lxc.aa_profile = unconfined"
+        - "{{ (hostvars[physical_host | default('localhost')]['ansible_distribution_version'] == '18.04') | ternary('lxc.apparmor.profile', 'lxc.aa_profile') }} = unconfined"
         - "lxc.cgroup.devices.allow = b *:* rwm"
     delegate_to: "{{ physical_host }}"
   - name: Wait for container connectivity

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -180,3 +180,5 @@ maas_notification_plan: npTechnicalContactsEmail
 maas_entity_name: "{{ ansible_hostname }}{{ maas_fqdn_extension }}"
 # Allow ceph services to be inside containers.
 maas_rpc_legacy_ceph: True
+
+ceph_origin: "{{ (hostvars['localhost']['ansible_distribution_version'] == '18.04') | ternary('distro', 'repository') }}"


### PR DESCRIPTION
In order for Bionic to work at this point, we need the following:

Utilise the ceph_origin 'distro' until download.ceph.com has packages
for Bionic.

Set the lxc.apparmor.profile setting instead of the lxc.aa_profile
setting, this changed in lxc version 3 (which is default in bionic).

Move the plugins into a role dir so it can be imported as a dependency
for upstream roles.

TODO: Update the roles - these need to be setup for bionic support, so
for OSA roles that means bumping to master - this doesn't include
keystone and galera/rabbitmq etc. which would only be needed in
keystone_rgw job. I've tested this by setting them to master, just to
release this as a "you can start messing about with Bionic".