### PR TITLE
CEPHSTORA-256:  fio benchmark code refactoring

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -31,8 +31,6 @@ osa_file_bench   - Random read and write tests using 4k blocks against a mounted
 ebs_rbd_bench    - Direct random read and write tests using 16k blocks and ioengine=rbd (DEFAULT)
 osa_rbd_bench    - Direct random read and write tests using 4k blocks and ioengine=rbd
 
-By default only the ebs_rbd_bench will run.  To run another test simply set it to true.
-
 Example:
 
 `osa_rbd_bench: true`

--- a/benchmark/fio_bench/fio_benchmark_run_tasks.yml
+++ b/benchmark/fio_bench/fio_benchmark_run_tasks.yml
@@ -36,11 +36,17 @@
     src: README_fio.md.j2
     dest: "{{ log_path }}/README.md"
 
+- name: lookup the user running benchmark
+  set_fact:
+    bench_user:  "{{ lookup('env', 'USER') }}"
+
 - name: "Make local benchmark directory"
   local_action:
     module: file
     state: directory
     path: "/opt/ceph_bench/logs/{{ run_id }}/{{ inventory_hostname_short }}"
+    owner: "{{ bench_user }}"
+    group: "{{ bench_user }}"
 
 - name: fetch log files
   local_action:

--- a/benchmark/fio_bench/fio_benchmark_setup.yml
+++ b/benchmark/fio_bench/fio_benchmark_setup.yml
@@ -90,41 +90,69 @@
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_benchmark_client']['stdout'], '\n'] | join('') }}"
         dest: "/etc/ceph/ceph.client.fiobench.keyring"
-    - name: Create a ceph device for benchmarking
-      command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
-      with_items:
-        - "bench_direct_EBS-{{ inventory_hostname_short }}"
-        - "bench_direct_RBD-{{ inventory_hostname_short }}"
-        - "bench_file-{{ inventory_hostname_short }}"
-      register: create_result
-      failed_when: create_result.rc not in [0,17]
-      changed_when: create_result.rc == 0
-    - name: Get mapped rbd-nbd devices
-      command: "rbd-nbd {{ _ceph_args }} list-mapped"
-      register: nbd_mapped_before
-    - name: Map nbd direct device
-      command: "rbd-nbd {{ _ceph_args }} map {{ _pool_name }}/bench_direct_EBS-{{ inventory_hostname_short }}"
-      when: "'bench_direct_EBS-' + inventory_hostname_short not in nbd_mapped_before.stdout"
-    - name: Map nbd file device
-      command: "rbd-nbd {{ _ceph_args }} map {{ _pool_name }}/bench_file-{{ inventory_hostname_short }}"
-      when: "'bench_file-' + inventory_hostname_short not in nbd_mapped_before.stdout"
-    - name: Get mapped rbd-nbd devices
-      command: "rbd-nbd {{ _ceph_args }} list-mapped"
-      register: nbd_mapped_after
-    - name: Set bench_direct_device_name
-      set_fact:
-        bench_direct_device_name: "{{ nbd_mapped_after.stdout | regex_search(regexp, '\\1') | join('') }}"
-      vars:
-        regexp: 'bench_direct_EBS-{{ inventory_hostname_short }}.*(\/dev\/nbd[0-9]+)'
-    - name: Set bench_file_device_name
-      set_fact:
-        bench_file_device_name: "{{ nbd_mapped_after.stdout | regex_search(regexp, '\\1') | join('') }}"
-      vars:
-        regexp: 'bench_file-{{ inventory_hostname_short }}.*(\/dev\/nbd[0-9]+)'
-    - name: Create xfs file system on device
-      filesystem:
-        fstype: xfs
-        device: "{{ bench_file_device_name }}"
+    - block:
+        - name: Create a ceph device for benchmarking
+          command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
+          with_items:
+            - "bench_direct_EBS-{{ inventory_hostname_short }}"
+          register: create_result
+          failed_when: create_result.rc not in [0,17]
+          changed_when: create_result.rc == 0
+        - name: Get mapped rbd-nbd devices
+          command: "rbd-nbd {{ _ceph_args }} list-mapped"
+          register: nbd_mapped_before
+        - name: Map nbd direct device
+          command: "rbd-nbd {{ _ceph_args }} map {{ _pool_name }}/bench_direct_EBS-{{ inventory_hostname_short }}"
+          when: "'bench_direct_EBS-' + inventory_hostname_short not in nbd_mapped_before.stdout"
+        - name: Get mapped rbd-nbd devices
+          command: "rbd-nbd {{ _ceph_args }} list-mapped"
+          register: nbd_mapped_after
+        - name: Set bench_direct_device_name
+          set_fact:
+            bench_direct_device_name: "{{ nbd_mapped_after.stdout | regex_search(regexp, '\\1') | join('') }}"
+          vars:
+            regexp: 'bench_direct_EBS-{{ inventory_hostname_short }}.*(\/dev\/nbd[0-9]+)'
+      when: bench_direct_EBS|default(false)
+
+    - block:
+        - name: Create a ceph device for benchmarking
+          command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
+          with_items:
+            - "bench_file-{{ inventory_hostname_short }}"
+          register: create_result
+          failed_when: create_result.rc not in [0,17]
+          changed_when: create_result.rc == 0
+        - name: Map nbd file device
+          command: "rbd-nbd {{ _ceph_args }} map {{ _pool_name }}/bench_file-{{ inventory_hostname_short }}"
+          when: "'bench_file-' + inventory_hostname_short not in nbd_mapped_before.stdout"
+        - name: Get mapped rbd-nbd devices
+          command: "rbd-nbd {{ _ceph_args }} list-mapped"
+          register: nbd_mapped_after
+        - name: Set bench_file_device_name
+          set_fact:
+            bench_file_device_name: "{{ nbd_mapped_after.stdout | regex_search(regexp, '\\1') | join('') }}"
+          vars:
+            regexp: 'bench_file-{{ inventory_hostname_short }}.*(\/dev\/nbd[0-9]+)'
+        - name: Create xfs file system on device
+          filesystem:
+            fstype: xfs
+            device: "{{ bench_file_device_name }}"
+        - name: Mount image
+          mount:
+            src: "{{ bench_file_device_name }}"
+            fstype: "xfs"
+            name: "/mnt/fio_bench"
+            state: mounted
+      when: bench_file|default(false)
+    - block:
+        - name: Create a ceph device for benchmarking
+          command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
+          with_items:
+            - "bench_direct_RBD-{{ inventory_hostname_short }}"
+          register: create_result
+          failed_when: create_result.rc not in [0,17]
+          changed_when: create_result.rc == 0
+      when: bench_direct_RBD|default(false)
     - name: Create benchmark directories
       file:
         state: directory
@@ -143,12 +171,6 @@
     # In py2 ConfigParser cant strip spaces around delimiters FIO needs that.
     - name: Manually strip spaces around delimiters
       shell: "sed -i 's/ = /=/g' /opt/ceph_bench/*.cfg"
-    - name: Mount image
-      mount:
-        src: "{{ bench_file_device_name }}"
-        fstype: "xfs"
-        name: "/mnt/fio_bench"
-        state: mounted
   roles:
     - ceph-defaults
     - ceph-common

--- a/benchmark/fio_bench/fio_benchmark_setup.yml
+++ b/benchmark/fio_bench/fio_benchmark_setup.yml
@@ -90,6 +90,18 @@
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_benchmark_client']['stdout'], '\n'] | join('') }}"
         dest: "/etc/ceph/ceph.client.fiobench.keyring"
+    - name: Set default bench_direct_device_name
+      set_fact:
+        bench_direct_device_name: ""
+    - block:
+        - name: Create a ceph device for benchmarking
+          command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
+          with_items:
+            - "bench_direct_RBD-{{ inventory_hostname_short }}"
+          register: create_result
+          failed_when: create_result.rc not in [0,17]
+          changed_when: create_result.rc == 0
+      when: (ebs_rbd_bench|default(false)) or (osa_rbd_bench|default(false))
     - block:
         - name: Create a ceph device for benchmarking
           command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
@@ -112,7 +124,7 @@
             bench_direct_device_name: "{{ nbd_mapped_after.stdout | regex_search(regexp, '\\1') | join('') }}"
           vars:
             regexp: 'bench_direct_EBS-{{ inventory_hostname_short }}.*(\/dev\/nbd[0-9]+)'
-      when: bench_direct_EBS|default(false)
+      when: ebs_direct_bench|default(false)
 
     - block:
         - name: Create a ceph device for benchmarking
@@ -122,7 +134,10 @@
           register: create_result
           failed_when: create_result.rc not in [0,17]
           changed_when: create_result.rc == 0
-        - name: Map nbd file device
+        - name: Get mapped rbd-nbd devices
+          command: "rbd-nbd {{ _ceph_args }} list-mapped"
+          register: nbd_mapped_before
+        - name: Map nbd direct device
           command: "rbd-nbd {{ _ceph_args }} map {{ _pool_name }}/bench_file-{{ inventory_hostname_short }}"
           when: "'bench_file-' + inventory_hostname_short not in nbd_mapped_before.stdout"
         - name: Get mapped rbd-nbd devices
@@ -143,16 +158,7 @@
             fstype: "xfs"
             name: "/mnt/fio_bench"
             state: mounted
-      when: bench_file|default(false)
-    - block:
-        - name: Create a ceph device for benchmarking
-          command: "rbd {{ _ceph_args }} create {{ _pool_name }}/{{ item }} -s {{ _size }}"
-          with_items:
-            - "bench_direct_RBD-{{ inventory_hostname_short }}"
-          register: create_result
-          failed_when: create_result.rc not in [0,17]
-          changed_when: create_result.rc == 0
-      when: bench_direct_RBD|default(false)
+      when: (ebs_file_bench|default(false)) or (osa_file_bench|default(false))
     - name: Create benchmark directories
       file:
         state: directory
@@ -160,6 +166,7 @@
       with_items:
         - /opt/ceph_bench/logs
         - /mnt/fio_bench
+    
     - name: Template out fio_bench files
       config_template:
         src: "templates/{{ item.src }}"

--- a/benchmark/fio_benchmark.yml
+++ b/benchmark/fio_benchmark.yml
@@ -5,8 +5,10 @@
   tasks:
     - name: fail when none of the benchmarks are chosen
       fail:
-        msg: "Set atleast one of the benchmark options to true. Options are: bench_direct_EBS, bench_file, bench_direct_RBD"
-      when: not ((bench_direct_EBS | default(false)) or (bench_file | default(false)) or (bench_direct_RBD | default(false)))
+        msg: "Set atleast one of the benchmark options to true.
+              Options are: ebs_direct_bench, ebs_file_bench, osa_file_bench, ebs_rbd_bench, osa_rbd_bench"
+      when: not ((ebs_direct_bench | default(false)) or (ebs_file_bench | default(false)) or (osa_file_bench | default(false)) or
+                 (ebs_rbd_bench | default(false)) or (osa_rbd_bench | default(false)))
 
 - include: fio_bench/fio_benchmark_setup.yml
 - include: fio_bench/fio_benchmark_run.yml

--- a/benchmark/fio_benchmark.yml
+++ b/benchmark/fio_benchmark.yml
@@ -1,4 +1,13 @@
 ---
+- name: Run pre-check
+  hosts:
+    - localhost
+  tasks:
+    - name: fail when none of the benchmarks are chosen
+      fail:
+        msg: "Set atleast one of the benchmark options to true. Options are: bench_direct_EBS, bench_file, bench_direct_RBD"
+      when: not ((bench_direct_EBS | default(false)) or (bench_file | default(false)) or (bench_direct_RBD | default(false)))
+
 - include: fio_bench/fio_benchmark_setup.yml
 - include: fio_bench/fio_benchmark_run.yml
 - include: fio_bench/fio_benchmark_cleanup.yml

--- a/playbooks/group_vars/benchmark_hosts/00-defaults.yml
+++ b/playbooks/group_vars/benchmark_hosts/00-defaults.yml
@@ -69,7 +69,7 @@ fio_bench_list_default:
     rw: write
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ ebs_rbd_bench | default(true) }}"
+    run_bench: "{{ ebs_rbd_bench | default(false) }}"
   - src: "fio_direct_test.cfg.j2"
     name: "fio_rbd_1M_read_test_EBS"
     override: "{{ fio_rbd_read_test_1024k_overrides | default({}) }}"
@@ -78,7 +78,7 @@ fio_bench_list_default:
     rw: read
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ ebs_rbd_bench | default(true) }}"
+    run_bench: "{{ ebs_rbd_bench | default(false) }}"
   - src: "fio_rw_mix.cfg.j2"
     name: "fio_rbd_1M_rw_mix_EBS"
     override: "{{ fio_rbd_rw_mix_1024k_overrides | default({}) }}"
@@ -86,7 +86,7 @@ fio_bench_list_default:
     ioengine: rbd
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ osa_rbd_bench | default(true) }}"
+    run_bench: "{{ osa_rbd_bench | default(false) }}"
   - src: "fio_direct_test.cfg.j2"
     name: "fio_rbd_4k_randwrite_test_OSA"
     override: "{{ fio_rbd_write_test_4k_overrides | default({}) }}"
@@ -131,7 +131,7 @@ fio_bench_list_default:
     rw: randwrite
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ ebs_rbd_bench | default(true) }}"
+    run_bench: "{{ ebs_rbd_bench | default(false) }}"
   - src: "fio_direct_test.cfg.j2"
     name: "fio_rbd_16k_randread_test_OSA"
     override: "{{ fio_rbd_read_test_16k_overrides | default({}) }}"
@@ -140,7 +140,7 @@ fio_bench_list_default:
     rw: randread
     iodepth: 8
     numjobs: 1
-    run_bench: "{{ ebs_rbd_bench | default(true) }}"
+    run_bench: "{{ ebs_rbd_bench | default(false) }}"
 
 fio_bench_list: "{{ (fio_bench_list_default | union(fio_bench_list_extras)) }}"
 fio_bench_list_extras: []


### PR DESCRIPTION
First pass of refactoring benchmark code.
This should help running specific benchmarks and create only required devices in the rados pool.