### PR TITLE
Move make package install to run_tests instead of bootstrap-ansible

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -175,7 +175,7 @@ if [[ ! -d tests/common ]]; then
   git clone https://github.com/openstack/openstack-ansible-tests -b stable/pike tests/common
 fi
 if [ "${RE_JOB_SCENARIO}" = "build_docs" ]; then
-  DEBIAN_FRONTEND=noninteractive sudo apt -y install docker.io
+  DEBIAN_FRONTEND=noninteractive sudo apt -y install docker.io make
   cd ${CLONE_DIR}/docs
   make docs
 else 

--- a/scripts/bootstrap-ansible.sh
+++ b/scripts/bootstrap-ansible.sh
@@ -42,7 +42,7 @@ case ${DISTRO_ID} in
           git python-all python-dev curl python2.7-dev build-essential \
           libssl-dev libffi-dev netcat python-requests python-openssl python-pyasn1 \
           python-netaddr python-prettytable python-crypto python-yaml \
-          python-virtualenv make
+          python-virtualenv
         ;;
 esac
 


### PR DESCRIPTION
We don't need make as part of the production environment for deploying
Ceph, so we should set it up solely for the purposes of generating the
documentation.