### PR TITLE
CEPHSTORA-283 Adjust RGW options for use with Ironic

### DIFF
--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -134,9 +134,9 @@ radosgw_keystone_ssl: false
 
 # Default this to ceph-ansible default so VIPs can be configured
 radosgw_civetweb_port: 8080
-radosgw_service_publicurl: "https://{{ external_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
-radosgw_service_adminurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
-radosgw_service_internalurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1"
+radosgw_service_publicurl: "https://{{ external_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1/%(tenant_id)s"
+radosgw_service_adminurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1/%(tenant_id)s"
+radosgw_service_internalurl: "http://{{ internal_lb_vip_address }}:{{ radosgw_civetweb_port }}/swift/v1/%(tenant_id)s"
 
 ## RadosGW VIP for HAProxy
 external_lb_vip_address: 127.0.0.1

--- a/playbooks/group_vars/rgws/00-defaults.yml
+++ b/playbooks/group_vars/rgws/00-defaults.yml
@@ -39,3 +39,5 @@ ceph_conf_overrides_rgw_keystone:
     rgw_keystone_admin_domain: default
     rgw_keystone_accepted_roles: 'Member, _member_, admin'
     rgw_s3_auth_use_keystone: true
+    rgw_swift_account_in_url: true
+    rgw_keystone_implicit_tenants: true

--- a/releasenotes/notes/rgw_endpoint_ironic-ddb182811e9413aa.yaml
+++ b/releasenotes/notes/rgw_endpoint_ironic-ddb182811e9413aa.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - Adjust the defaults for Rados Gateway and Keystone
+    integration. The RGW endpoint URLs now include the
+    tenant_id, and the Rados Gateway settings include the
+    ``rgw_swift_account_in_url`` and
+    ``rgw_keystone_implicit_tenants`` options which are
+    now both set to ``true`` when integrating with
+    OpenStack and Keystone.


### PR DESCRIPTION
Ironic requires the Swift Account to be in the URL, there are RGW
settings to achieve this.

Additionally, the endpoint URL needs to be adjusted accordingly.