### PR TITLE
CEPHSTORA-302 Fix phobos play order and vars

### DIFF
--- a/phobos/cap-vars.yml
+++ b/phobos/cap-vars.yml
@@ -1,7 +1,6 @@
 ---
 log_flavor: vm-osa-aio
 log_image: a4a9bc69-de27-4cec-903a-cf57be693738
-log_count: 1
 
 stor_flavor: ironic-rpc-storage-cap
 stor_image: 78856fa6-1de4-42d3-b545-466f6501e21f

--- a/phobos/cap-vlan-vars.yml
+++ b/phobos/cap-vlan-vars.yml
@@ -1,10 +1,11 @@
 ---
 log_flavor: vm-osa-aio
 log_image: a4a9bc69-de27-4cec-903a-cf57be693738
-log_count: 1
 
 stor_flavor: ironic-rpc-storage-cap
 stor_image: 78856fa6-1de4-42d3-b545-466f6501e21f
+
+ironic: true
 
 security_group: 58753c65-1804-4eee-8349-77f1c5573001
 external_network: ironic

--- a/phobos/perf-vars.yml
+++ b/phobos/perf-vars.yml
@@ -6,6 +6,8 @@ log_count: 1
 stor_flavor: ironic-rpc-storage-perf
 stor_image: 78856fa6-1de4-42d3-b545-466f6501e21f
 
+ironic: true
+
 security_group: 58753c65-1804-4eee-8349-77f1c5573001
 external_network: ironic
 networks:

--- a/phobos/perf-vlan-vars.yml
+++ b/phobos/perf-vlan-vars.yml
@@ -1,10 +1,11 @@
 ---
 log_flavor: vm-osa-aio
 log_image: a4a9bc69-de27-4cec-903a-cf57be693738
-log_count: 1
 
 stor_flavor: ironic-rpc-storage-perf
 stor_image: 78856fa6-1de4-42d3-b545-466f6501e21f
+
+ironic: true
 
 security_group: 58753c65-1804-4eee-8349-77f1c5573001
 external_network: ironic

--- a/playbooks/phobos-deploy-nodes.yml
+++ b/playbooks/phobos-deploy-nodes.yml
@@ -7,6 +7,7 @@
   vars:
     log_count: 0
     haproxy_count: 0
+    ironic: false
 
   tasks:
     - name: Check for required variables

--- a/playbooks/phobos-deploy.yml
+++ b/playbooks/phobos-deploy.yml
@@ -2,8 +2,8 @@
 - name: Deploy infrastructure
   import_playbook: phobos-deploy-nodes.yml
 
-- name: Add hosts
-  import_playbook: write-hosts-file.yml
-
 - name: Bootstrap
   import_playbook: phobos-bootstrap.yml
+
+- name: Add hosts
+  import_playbook: write-hosts-file.yml

--- a/playbooks/templates/inventory_file.j2
+++ b/playbooks/templates/inventory_file.j2
@@ -6,7 +6,5 @@
 
 {% endfor %}
 [all:vars]
-ansible_user={{ hostvars[groups['mons']|first]['ansible_user'] }}
-ansible_become={{ hostvars[groups['mons']|first]['ansible_become'] }}
 ansible_ssh_extra_args={{ hostvars[groups['mons']|first]['ansible_ssh_extra_args'] }}
 ansible_python_interpreter={{ hostvars[groups['mons']|first]['ansible_python_interpreter'] }}


### PR DESCRIPTION
Fixing the order of the phobos-deploy.yml play so ceph_interfaces are
configured before the write-hosts play attempts to lookup the interface
ips.  The ironic boolean needed a default value.  Removed ansible_user
and ansible_become from inventory file.