### PR TITLE
CEPHSTORA-191 Fix versions of rsyslog/haproxy etc

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -2,22 +2,18 @@
   scm: git
   src: https://github.com/ceph/ceph-ansible
   version: v3.0.34
-- name: ../ceph_plugins
-  scm: git
-  src: https://git.openstack.org/openstack/openstack-ansible-plugins
-  version: 17.0.0.0b3
 - name: rsyslog_client
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_client
-  version: stable/pike
+  version: 17.0.4
 - name: haproxy_server
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
-  version: stable/pike
+  version: 17.0.4
 - name: rsyslog_server
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_server
-  version: stable/pike
+  version: 17.0.4
 - name: prometheus_server
   scm: git
   src: https://github.com/idealista/prometheus_server-role

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,10 +1,10 @@
 [defaults]
 
-library            = /etc/ansible/ceph_plugins/library:./library:/etc/ansible/ceph_roles/ceph-ansible/library
+library            = /etc/ansible/ceph_roles/ceph-ansible/library:./library:/etc/ansible/ceph_plugins/library
 # set plugin path directories here, separate with colons
 action_plugins     = /etc/ansible/ceph_plugins/action:/etc/ansible/ceph_roles/ceph-ansible/plugins/actions
 cache_plugins      = /etc/ansible/ceph_plugins/cache
-callback_plugins   = /etc/ansible/ceph_plugins/callback:/etc/ansible/ceph_roles/ceph-ansible/plugins/callback
+callback_plugins   = /etc/ansible/ceph_roles/ceph-ansible/plugins/callback:/etc/ansible/ceph_plugins/callback
 connection_plugins = /etc/ansible/ceph_plugins/connection
 lookup_plugins     = /etc/ansible/ceph_plugins/lookup
 inventory_plugins  = /etc/ansible/ceph_plugins/inventory

--- a/gating/check/run
+++ b/gating/check/run
@@ -203,7 +203,7 @@ if [ "${RE_JOB_SCENARIO}" = "bluestore" ]; then
 	export CEPH_BOOTSTRAP_OPTS="-e @tests/test-vars-bluestore.yml ${CEPH_BOOTSTRAP_OPTS}"
 fi
 if [[ ! -d tests/common ]]; then
-  git clone https://github.com/openstack/openstack-ansible-tests -b stable/pike tests/common
+  git clone https://github.com/openstack/openstack-ansible-tests -b stable/queens tests/common
 fi
 if [ "${RE_JOB_SCENARIO}" = "build_docs" ]; then
   DEBIAN_FRONTEND=noninteractive sudo apt -y install docker.io make

--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -1,23 +1,23 @@
 - name: lxc_hosts
   src: https://git.openstack.org/openstack/openstack-ansible-lxc_hosts
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: lxc_container_create
   src: https://git.openstack.org/openstack/openstack-ansible-lxc_container_create
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: apt_package_pinning
   src: https://git.openstack.org/openstack/openstack-ansible-apt_package_pinning
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: pip_install
   src: https://git.openstack.org/openstack/openstack-ansible-pip_install
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: os_keystone
   src: https://git.openstack.org/openstack/openstack-ansible-os_keystone
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: rpc-maas/tests/common
   src: https://git.openstack.org/openstack/openstack-ansible-tests
   scm: git
@@ -25,24 +25,28 @@
 - name: galera_client
   src: https://git.openstack.org/openstack/openstack-ansible-galera_client
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: galera_server
   src: https://git.openstack.org/openstack/openstack-ansible-galera_server
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: rabbitmq_server
   src: https://git.openstack.org/openstack/openstack-ansible-rabbitmq_server
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: openstack_openrc
   src: https://git.openstack.org/openstack/openstack-ansible-openstack_openrc
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: openstack_hosts
   src: https://git.openstack.org/openstack/openstack-ansible-openstack_hosts
   scm: git
-  version: stable/pike
+  version: stable/queens
 - name: memcached_server
   src: https://git.openstack.org/openstack/openstack-ansible-memcached_server
   scm: git
-  version: stable/pike
+  version: stable/queens
+- name: ../ceph_plugins
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-plugins
+  version: stable/queens

--- a/tests/build-containers.yml
+++ b/tests/build-containers.yml
@@ -22,3 +22,13 @@
         timeout: "{{ lxc_container_wait_params.timeout | default(omit) }}"
   vars_files:
     - test-vars.yml
+
+# We need pip on openstack containers
+- name: Execute the openstack-host role on containers
+  hosts: keystone_all:galera_all
+  become: true
+  gather_facts: true
+  roles:
+    - role: "openstack_hosts"
+  vars_files:
+    - test-vars.yml


### PR DESCRIPTION
We shouldn't use head of branch for a specific release. We should
instead use the released versions that will remain stable.

Additionally, ceph-ansible carries all the plugins it requires, we
should utilise those instead of getting the openstack-ansible-plugins
directory.