### PR TITLE
CEPHSTORA-321 Add OSA plugins as a base role

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -30,3 +30,7 @@
   scm: git
   src: https://github.com/cloudalchemy/ansible-alertmanager
   version: 0.11.6
+- name: ../ceph_plugins
+  scm: git
+  src: https://git.openstack.org/openstack/openstack-ansible-plugins
+  version: 17.0.4

--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -46,7 +46,3 @@
   src: https://git.openstack.org/openstack/openstack-ansible-memcached_server
   scm: git
   version: stable/queens
-- name: ../ceph_plugins
-  scm: git
-  src: https://git.openstack.org/openstack/openstack-ansible-plugins
-  version: stable/queens


### PR DESCRIPTION
The OSA plugins are required to perform keystone integration.
Another solution would be to utilize the Shade modules, and use the
openstack_openrc role to add a default clouds.yaml. However, until we
use Ansible 2.5.0 the os_keystone_endpoint module is not available, and
we wouldn't be able to create the endpoints. As such this is the
simplest approach to fixing up our integration jobs and ensuring we can
create keystone endpoints/users/roles/services.