### PR TITLE
CEPHSTORA-323 Fix rpco_integration for Queens+

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -78,6 +78,9 @@ function _configure_rpco {
   if [ "${RE_JOB_SCENARIO}" = "rpco_newton" ]; then
     export OSA_DIR="${RPCO_DIR}/openstack-ansible"
     export SECRETS_FILE="/etc/openstack_deploy/user_osa_secrets.yml"
+  elif [ "${RE_JOB_SCENARIO}" != "rpco_pike" ]; then
+    ## For Queens onwards (e.g. not Pike or Newton) the inventory dir has moved
+    export CINDER_ENVD="../inventory/env.d/cinder.yml"
   fi
   if [[ ! -d /opt/rpc-openstack ]]; then
     git clone https://github.com/rcbops/rpc-openstack -b ${RPCO_VERSION} --recursive ${RPCO_DIR}

--- a/tests/rpco_vars/user_rpc_ceph_vars.yml
+++ b/tests/rpco_vars/user_rpc_ceph_vars.yml
@@ -1,11 +1,16 @@
 ---
 # Ensure only the required services are built
+# From Queens onward haproxy is a separate file.
+# Prior to Queens use nova.yml.aio twice as a way to
+# not fail, but not do anything.
 openstack_confd_entries:
   - name: cinder.yml.aio
   - name: glance.yml.aio
   - name: keystone.yml.aio
   - name: neutron.yml.aio
   - name: nova.yml.aio
+  - name: "{{ (lookup('env','RE_JOB_SCENARIO') in ['rpco_newton', 'rpco_pike']) | ternary('nova.yml.aio', 'haproxy.yml.aio') }}"
+
 bootstrap_host_loopback_swift: false
 
 ceph_mons:

--- a/tests/setup-data-disk.yml
+++ b/tests/setup-data-disk.yml
@@ -73,5 +73,6 @@
     with_items:
       - { mount_point: /openstack, device: "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}1"}
       - { mount_point: /var/lib/lxc, device: "/dev/{{ bootstrap_host_data_disk_device | regex_replace('!(.*)$','/\\1p') }}2"}
+    when: data_disk_partitions.rc == 1 or ((bootstrap_host_data_disk_device_force | default(false)) | bool)
     tags:
       - mount-data-partitions


### PR DESCRIPTION
In Queens release of OSA the inventory directory moved from the
playbooks dir to the top level of the OSA directory.

Additionally, the haproxy user_config moved into it's own scenario file
which needs to be included.