### PR TITLE
CEPHSTORA-325 Specify cpu states to adjust and allow enabling

### DIFF
--- a/playbooks/group_vars/osds/00-defaults.yml
+++ b/playbooks/group_vars/osds/00-defaults.yml
@@ -2,5 +2,9 @@
 ## This is a defaults file, it's likely to be changed during repo updates
 ## To override, or update settings, or configuration, create a new file
 ## in this directory, e.g. "overrides.yml" which will take precedence.
+disable_cpuidle_states: [ 2, 3, 4 ]
+# To enable cpuidle states add enable_cpuidle_states to your overrides file
+# Specifying the ids to enable.
+enable_cpuidle_states: []
 ceph_conf_overrides_osd_extra: {}
 ceph_conf_overrides_osd: "{{ ceph_conf_overrides_osd_extra }}"

--- a/playbooks/tune-cpufreq.yml
+++ b/playbooks/tune-cpufreq.yml
@@ -40,15 +40,30 @@
 
     - name: Disable cpuidle states
       shell: "echo 1 | tee /sys/devices/system/cpu/cpu*/cpuidle/state{{ item }}/disable"
-      with_sequence: start=2 end=4
+      with_items: "{{ disable_cpuidle_states }}"
       when: cpuidle_check.stat.exists
 
-    - name: Persist cpuidle in rc.local
+    - name: Persist cpuidle disable in rc.local
       lineinfile:
         path: /etc/rc.local
         line: "echo 1 | tee /sys/devices/system/cpu/cpu*/cpuidle/state{{ item }}/disable"
+        regexp: '^echo (0|1) \| tee /sys/devices/system/cpu/cpu\*/cpuidle/state{{ item }}/disable'
         insertbefore: '^exit 0$'
-      with_sequence: start=2 end=4
+      with_items: "{{ disable_cpuidle_states }}"
+      when: cpuidle_check.stat.exists
+
+    - name: Enable cpuidle states
+      shell: "echo 0 | tee /sys/devices/system/cpu/cpu*/cpuidle/state{{ item }}/disable"
+      with_items: "{{ enable_cpuidle_states }}"
+      when: cpuidle_check.stat.exists
+
+    - name: Persist cpuidle enable in rc.local
+      lineinfile:
+        path: /etc/rc.local
+        line: "echo 0 | tee /sys/devices/system/cpu/cpu*/cpuidle/state{{ item }}/disable"
+        regexp: '^echo (0|1) \| tee /sys/devices/system/cpu/cpu\*/cpuidle/state{{ item }}/disable'
+        insertbefore: '^exit 0$'
+      with_items: "{{ enable_cpuidle_states }}"
       when: cpuidle_check.stat.exists
 
     - name: Check cpufreq

--- a/releasenotes/notes/cpuidle_states-32a3a07d5b6202d0.yaml
+++ b/releasenotes/notes/cpuidle_states-32a3a07d5b6202d0.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - The cpuidle states can now be disabled or enabled using
+    ``disable_cpuidle_states`` and ``enable_cpuidle_states``
+    variables. These are a list of the states to disable and
+    or enable.
+    ``disable_cpuidle_states`` defaults to ``[ 2, 3, 4 ]``
+    and ``enable_cpuidle_states`` defaults to ``[]``.


### PR DESCRIPTION
This PR adds 2 variables, "enable_cpuidle_states" and
"disable_cpuidle_states", which will allow the operator to specify the
states to disable or enable.

NB if you specify the same values in both disable or enable it will
enable them. (Enabling takes precedence).