### PR TITLE
Add release note for version bump

### DIFF
--- a/releasenotes/notes/version_bump310718-121a3d6eca29bd59.yaml
+++ b/releasenotes/notes/version_bump310718-121a3d6eca29bd59.yaml
@@ -1,0 +1,16 @@
+---
+upgrade:
+  - Bump prometheus_server-role version from 1.3.1 to 1.4.0
+  - Bump prometheus_node_exporter-role from 1.2.6 to 2.0.0
+  - Bump ansible-alertmanager from 0.11.6 to 0.13.1
+  - Pin openstack-ansible-lxc_hosts from stable/queens to 17.0.4
+  - Pin openstack-ansible-lxc_container_create from stable/queens to 17.0.4
+  - Pin openstack-ansible-apt_package_pinning from stable/queens to 17.0.4
+  - Pin openstack-ansible-pip_install from stable/queens to 17.0.4
+  - Pin openstack-ansible-os_keystone from stable/queens to 17.0.4
+  - Pin openstack-ansible-galera_client from stable/queens to 17.0.4
+  - Pin openstack-ansible-galera_server from stable/queens to 17.0.4
+  - Pin openstack-ansible-rabbitmq_server from stable/queens to 17.0.4
+  - Pin openstack-ansible-openstack_openrc from stable/queens to 17.0.4
+  - Pin openstack-ansible-openstack_hosts from stable/queens to 17.0.4
+  - Pin openstack-ansible-memcached_server from stable/queens to 17.0.4


### PR DESCRIPTION
In https://github.com/rcbops/rpc-ceph/pull/213/ we bumped the versions
of various Ansible roles. This adds a release note for that.