### PR TITLE
RE-1698 Pin openstack-ansible-tests

### DIFF
--- a/tests/ansible-role-test-requirements.yml
+++ b/tests/ansible-role-test-requirements.yml
@@ -21,7 +21,7 @@
 - name: rpc-maas/tests/common
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-tests
-  version: master
+  version: b146d649e675d748a58af238c7b37138b8194f1f
 - name: galera_client
   scm: git
   src: https://git.openstack.org/openstack/openstack-ansible-galera_client


### PR DESCRIPTION
This commit pins openstack-ansible-tests as a recent change made to that
repo is breaking rpc-ceph tests. The failure will need to be
investigated and we can revert this commit once the team knows what's
going on.