### PR TITLE
Correcting error in release notes.

### DIFF
--- a/releasenotes/notes/update_deps-b91278014e746760.yaml
+++ b/releasenotes/notes/update_deps-b91278014e746760.yaml
@@ -1,6 +1,7 @@
 ---
 deprecations:
-  - ``ceph-ansible_increment_release.sh`` has been moved to
+  - Changes made to the way ceph-ansible increment releases
+    ``ceph-ansible_increment_release.sh`` has been moved to
     ``gating/update_dependencies/run`` which is an automated
     Release Engineering job that will run and automatically
     create a PR on a regular cadence.


### PR DESCRIPTION
There is a problem starting a line in release notes with a special
character `.