### PR TITLE
Add a new RE_JOB_SCENARIO build_releasenotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ To run an AIO scenario for Ceph you can run the following export on a general1-8
 or perf2-15 flavor instance, unless otherwise noted:
 #export RE_JOB_SCENARIO="name of scenario from below"
 
-**build_docs**
-This will build the project documentation using sphinx and place it in
-the directory `rpc-ceph/_build/html/index.html`  
+**build_releasenotes**
+This will build the project releae notes  using sphinx and place it in
+the directory `rpc-ceph/release/build/`  
 
 **functional**:
 This is a base AIO for Ceph, includes MaaS testing, this runs on each
@@ -178,13 +178,13 @@ a long time to build.
 
 NB: This requires a perf2-15 instance.
 
-**rpco_master**
-This is the same as the rpco_newton job but built against the master-rc branch
-of RPC-O.
-
 **rpco_pike**
 This is the same as the rpco_newton job but built against the pike-rc branch
 of RPC-O.
+
+**rpco_queens**
+This is the same as the rpco_newton and rpco-pike jobs but built against the 
+queens-rc branch of RPC-O.
 
 **keystone_rgw**:
 A basic keystone integration test, that will run on each commit.

--- a/gating/check/run
+++ b/gating/check/run
@@ -184,6 +184,13 @@ bash scripts/bootstrap-ansible.sh
 
 _download_dependent_components
 
+
+if [ "${RE_JOB_SCENARIO}" = "build_releasenotes" ]; then
+  pip install sphinx reno oslosphinx
+  sphinx-build -a -E -W -d releasenotes/build/doctrees \
+    -b html releasenotes/source releasenotes/build/html
+  exit
+fi
 if [ "${RE_JOB_SCENARIO}" != "rpco_newton" ]; then
   _get_data_disk
 fi


### PR DESCRIPTION
Adding in a new scenario to test and verify that release notes
will build correctly.  This should be the first step to creating
a gating job for it.