### PR TITLE
Release notes for dep_update

### DIFF
--- a/releasenotes/notes/CEPHSTORA-380-69f18aa9c470adfc.yaml
+++ b/releasenotes/notes/CEPHSTORA-380-69f18aa9c470adfc.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    Verion of ceph-ansible was incremented to ``v3.0.40`` from ``v3.0.39`` 
+
+    group name was changed from ``iscsi-gws`` to ``iscsigws``
+
+    Changes to playbooks/rolling_update.yml
+      ``jewel_minor_update: False``
+      New tasks added: 
+        ``get osd versions``
+        ``set_fact ceph_versions_osd``
+        ``osd set sortbitwise``


### PR DESCRIPTION
Added release notes for latest dependency update.    This was an experiment.   From now on the release notes should probably added to the original commit.   