### PR TITLE
CEPHSTORA-489 Add ceph pinning test

### DIFF
--- a/releasenotes/notes/pin_by_default-2a410a82d5bcc398.yaml
+++ b/releasenotes/notes/pin_by_default-2a410a82d5bcc398.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Enabled repository pinning by default and pinned to
+    luminous version 12.2.8.

--- a/tests/host_vars/mds1.yml
+++ b/tests/host_vars/mds1.yml
@@ -1,0 +1,16 @@
+---
+ansible_host: "{{ ansible_addr_prefix }}.38"
+ceph_storage_address: "{{ storage_addr_prefix }}.38"
+container_networks:
+  management_address:
+    address: "{{ ansible_host }}"
+    bridge: "br-mgmt"
+    interface: "eth1"
+    netmask: "255.255.252.0"
+    type: "veth"
+  storage_address:
+    address: "{{ ceph_storage_address }}"
+    bridge: "br-storage"
+    interface: "eth2"
+    netmask: "255.255.252.0"
+    type: "veth"

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -32,6 +32,7 @@
   when: radosgw_keystone | bool
 
 ## Tests
+- include: test-version.yml
 - include: test-rgw.yml
 - include: ../benchmark/fio_benchmark.yml
   when: (test_run_bench | default(False)) | bool

--- a/tests/test-version.yml
+++ b/tests/test-version.yml
@@ -1,0 +1,17 @@
+---
+- hosts: mons[0]
+  gather_facts: false
+  tasks:
+    - name: Get Ceph Versions
+      command: ceph -f json versions
+      changed_when: false
+      register: ceph_versions_out
+
+    - name: Import JSON
+      set_fact:
+        ceph_versions: "{{ ceph_versions_out.stdout | from_json }}"
+
+    - name: Check Ceph Versions
+      assert:
+        that: "item == 'ceph version 12.2.8 (ae699615bac534ea496ee965ac6192cb7e0e07c0) luminous (stable)'"
+      with_items: "{{ ceph_versions.overall }}"


### PR DESCRIPTION
Adding a check all gates to confirm that the ceph version pinning is
working and only the version of ceph we are expecting is installed.

Fixed an issue with the mds container in the tests missing the storage
network.