### PR TITLE
CEPHSTORA-268 Add openstack pools by default

### DIFF
--- a/playbooks/group_vars/all/00-defaults.yml
+++ b/playbooks/group_vars/all/00-defaults.yml
@@ -39,6 +39,8 @@ journal_size: "{{ osd_journal_size | default('20480') }}"
 
 osd_objectstore: filestore
 
+openstack_config: true
+
 radosgw_civetweb_num_threads: 8192
 ceph_conf_overrides_all:
    global:

--- a/releasenotes/notes/openstack_config_default-982094b45c957a84.yaml
+++ b/releasenotes/notes/openstack_config_default-982094b45c957a84.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Set ``openstack_config: True`` as the default so openstack pools and auth
+    are created by default.  For standalone deployments ``openstack_config``
+    will need to be overridden to ``False`` to avoid unneccsary keys and
+    pools.


### PR DESCRIPTION
In most cases we are deploying Ceph to back openstack and will need
these pools.  For standalone ceph installs we will need to override
openstack_config to False or clean up the extra pools and auth that will
be created.