### PR TITLE
CEPHSTORA-493 Fix gating false positives

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -244,6 +244,9 @@ else
   ${ANSIBLE_BINARY} tests/setup-ceph-aio.yml \
                    -i ${ANSIBLE_INVENTORY} \
                    -e @tests/test-vars.yml ${CEPH_BOOTSTRAP_OPTS}
+  ${ANSIBLE_BINARY} tests/test-ceph-aio.yml \
+                   -i ${ANSIBLE_INVENTORY} \
+                   -e @tests/test-vars.yml ${CEPH_BOOTSTRAP_OPTS}
 fi
 if [[ "${RE_JOB_SCENARIO}" =~ ^rpco_ ]]; then
   _deploy_rpco

--- a/tests/setup-ceph-aio.yml
+++ b/tests/setup-ceph-aio.yml
@@ -30,17 +30,3 @@
   when: radosgw_keystone | bool
 - include: setup-swiftoperator-user.yml
   when: radosgw_keystone | bool
-
-## Tests
-- include: test-version.yml
-- include: test-rgw.yml
-- include: ../benchmark/fio_benchmark.yml
-  when: (test_run_bench | default(False)) | bool
-- include: ../benchmark/rgw_benchmark.yml
-  when: (test_run_bench | default(False)) | bool
-
-## Logging setup and tests
-# This is done after to allow time for the logs
-# to exist.
-- include: ../playbooks/ceph-setup-logging.yml
-- include: test-logging.yml

--- a/tests/test-ceph-aio.yml
+++ b/tests/test-ceph-aio.yml
@@ -1,0 +1,14 @@
+---
+## Tests
+- include: test-version.yml
+- include: test-rgw.yml
+- include: ../benchmark/fio_benchmark.yml
+  when: (test_run_bench | default(False)) | bool
+- include: ../benchmark/rgw_benchmark.yml
+  when: (test_run_bench | default(False)) | bool
+
+## Logging setup and tests
+# This is done after to allow time for the logs
+# to exist.
+- include: ../playbooks/ceph-setup-logging.yml
+- include: test-logging.yml


### PR DESCRIPTION
Upgrading to ceph-ansible 3.1.x is producing false positives in the
rpc-ceph gates due to the inclusion of installer status as part of
ceph-ansible.  Breaking the test plays out to separate runs so ones
plays status does mask an error in another play.