### PR TITLE
Modify tests/inventory hosts group

### DIFF
--- a/tests/inventory
+++ b/tests/inventory
@@ -15,8 +15,8 @@ localhost
 [repo_servers]
 allsvc
 
-[hosts]
-localhost
+[hosts:children]
+all_containers
 
 [all_containers]
 mon1


### PR DESCRIPTION
This group does not appear to utilized by any of the existing test
scenarios. This change will natively allow rpc-maas to deploy within
ceph aio scenarios used by this inventory source. Reference: NATT-26.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>