### PR TITLE
JIRA: CEPHSTORA-499 Fix hanging aio jobs

### DIFF
--- a/tests/setup-ceph-storage.yml
+++ b/tests/setup-ceph-storage.yml
@@ -10,6 +10,7 @@
 
 - name: Playbook for configuring fake storage on Ceph hosts
   hosts: osds
+  serial: 1
   become: true
   pre_tasks:
   - name: Gather variables for each operating system


### PR DESCRIPTION
When setting up the storage for aio devices the osds
(osd1, osd2, allsvc), the losetup task has a tendancy
to hang.  May tasks in this play are delegating to the
physical host and running disk related tasks in parallel.
The losetup task seems to hang often when this happens
resulting in failed builds due time timeouts on the task.
This change is to set up the play to run things in serial
to cut down on conflicts.