### PR TITLE
rpc-ceph decom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Decom Note:
+
+rpc-ceph is no longer being developed or tested.  Please use the
+upstream ceph-ansible playbooks for any future deployments. 
+
 # rpc-ceph and ceph-ansible
 
 ``rpc-ceph`` deploys Ceph as an RPC stand-alone platform in a uniform,


### PR DESCRIPTION
This is no longer being used after the last re-org.  We
depend on the upstream ceph-ansible and any deployment
tool documentation for future installs.